### PR TITLE
Travis CI + 1.2.64

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,40 @@
+language: generic
+sudo: required
+branches:
+  except:
+  - master
+env:
+  global:
+    - VERSION=1.2.55
+    - DAEMON_VERSION=1.2
+    - RELEASE=1
+  matrix:
+  - OS_TYPE=fedora OS_VERSION=24
+  - OS_TYPE=fedora OS_VERSION=23
+  - OS_TYPE=centos OS_VERSION=7
+services:
+- docker
+before_install:
+- echo 'DOCKER_OPTS="-H tcp://127.0.0.1:2375 -H unix:///var/run/docker.sock -s devicemapper"'
+  | sudo tee /etc/default/docker > /dev/null
+- sudo service docker restart
+- sleep 5
+- sudo docker pull ${OS_TYPE}:${OS_VERSION}
+script:
+- sudo docker run --rm=true -v `pwd`:/base-src:rw -t ${OS_TYPE}:${OS_VERSION} /bin/bash
+  -c /base-src/ci/${OS_TYPE}.sh
+- sudo mv displaylink-${VERSION}-${RELEASE}.src.rpm ${OS_TYPE}-${OS_VERSION}-displaylink-${VERSION}-${RELEASE}.src.rpm
+- sudo mv x86_64/displaylink-${VERSION}-${RELEASE}.x86_64.rpm ${OS_TYPE}-${OS_VERSION}-displaylink-${VERSION}-${RELEASE}.x86_64.rpm
+- sudo mv i386/displaylink-${VERSION}-${RELEASE}.i386.rpm ${OS_TYPE}-${OS_VERSION}-displaylink-${VERSION}-${RELEASE}.i386.rpm
+- sudo chown `id -u`:`id -g` -R .
+deploy:
+  provider: releases
+  skip_cleanup: true
+  on:
+    tags: true
+  api_key:
+    secure: 1b1NDFYX+9shoLWuZnqUIdZ0IBr5jdFcY57FGnIqtr+Dxjl2uyLj6c1rYJvtoGCADwRh/1M2hY0/kEMegYiKwrt7gwtmfDYdVHD1njttrsPyCs4Kvp4HUTRCfDgWHFL0AWSEw986ksF5Ig41tMux2KWIfWvhrtmU5o9l+Z/5tNU3rHryMoOPIf7IGoPFZWcPLqOxZzdZnTkbPZZkmu3ryCBf0mQ1wG7I6ZoRLci7JPFTPmQlllhflcPzUXMv6XgwzTN6t0IQOC1DCZJ+yUtGvcI2VL3XLwGXG1bJhVpU9oURu6mMq/Wsb8PaKuIAFB5SGvHFRLITpR42NW9Mv5yMyOZFAe+AmqeEgmhtcPAi1qpvy7jqYMRerydY6znPaVFpAUyuLvqLAJLZXuK85VpPXHLMjaIcQnJdw0gwY/CANESWbWHP1MRYgVFLB0x01yLq38tqbkf85IGsnrEDHaD9Tc8EsfAZFN56EQ0im3laxwFwfhuv3WHle1kAibpfNv2cMoEhBXjFVwjW/YooCfYsPUuHsEzgX10rtqahaa3JYPf8nRtharoXTnikZt+1SkjiaDQoVhCJTqKwePYaLgsG9OblAcKnKclF2znp6DTwK5fyKQa54gWrLAlqI11Z2v9fLqPZslNd+pt8CyHC5NpAgSG+lwtLcsGB+q2JY/fer8A=
+  file: 
+    - ${OS_TYPE}-${OS_VERSION}-displaylink-${VERSION}-${RELEASE}.src.rpm
+    - ${OS_TYPE}-${OS_VERSION}-displaylink-${VERSION}-${RELEASE}.x86_64.rpm
+    - ${OS_TYPE}-${OS_VERSION}-displaylink-${VERSION}-${RELEASE}.i386.rpm

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,8 +5,8 @@ branches:
   - master
 env:
   global:
-    - VERSION=1.2.55
-    - DAEMON_VERSION=1.2
+    - VERSION=1.2.64
+    - DAEMON_VERSION=1.2.1
     - RELEASE=1
   matrix:
   - OS_TYPE=fedora OS_VERSION=24

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
-VERSION=1.2.55
-DAEMON_VERSION=1.2
-DOWNLOAD_ID=701 # This id number comes off the link on the displaylink website
+VERSION=1.2.64
+DAEMON_VERSION=1.2.1
+DOWNLOAD_ID=708 # This id number comes off the link on the displaylink website
 RELEASE=1
 
 .PHONY: srpm rpm

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,6 @@
 VERSION=1.2.55
 DAEMON_VERSION=1.2
+DOWNLOAD_ID=701 # This id number comes off the link on the displaylink website
 RELEASE=1
 
 .PHONY: srpm rpm
@@ -10,6 +11,9 @@ all: $(TARGETS)
 
 clean:
 	rm -f $(TARGETS) v$(VERSION).tar.gz
+
+DisplayLink\ USB\ Graphics\ Software\ for\ Ubuntu\ $(DAEMON_VERSION).zip:
+	wget -O DisplayLink\ USB\ Graphics\ Software\ for\ Ubuntu\ $(DAEMON_VERSION).zip http://www.displaylink.com/downloads/file?id=$(DOWNLOAD_ID)
 
 v$(VERSION).tar.gz:
 	wget -O v$(VERSION).tar.gz https://github.com/DisplayLink/evdi/archive/v$(VERSION).tar.gz

--- a/ci/centos.sh
+++ b/ci/centos.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+yum install -y gcc rpm-build make wget yum-utils --enablerepo=extras
+
+cd /base-src
+
+yum-builddep -y ./displaylink.spec
+
+chown `id -u`:`id -g` -R .
+
+make

--- a/ci/fedora.sh
+++ b/ci/fedora.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+dnf install -y rpm-build make gcc wget 'dnf-command(builddep)'
+
+cd /base-src
+
+dnf builddep -y --spec ./displaylink.spec
+
+make

--- a/displaylink.spec
+++ b/displaylink.spec
@@ -1,9 +1,9 @@
 %global debug_package %{nil}
-%define daemon_version 1.2.58
+%define daemon_version 1.2.65
 
 Name:		displaylink
-Version:	1.2.55
-Release:	2
+Version:	1.2.64
+Release:	1
 Summary:	DisplayLink VGA/HDMI driver for DL-5xxx, DL-41xx and DL-3xxx adapters
 
 Group:		User Interface/X Hardware Support
@@ -13,7 +13,7 @@ Source1:	displaylink.service
 Source2:	99-displaylink.rules
 Source3:        displaylink-sleep-extractor.sh
 # From http://www.displaylink.com/downloads/ubuntu.php
-Source4:	DisplayLink USB Graphics Software for Ubuntu 1.2.zip
+Source4:	DisplayLink USB Graphics Software for Ubuntu 1.2.1.zip
 ExclusiveArch:	i386 x86_64
 
 BuildRequires:	libdrm-devel
@@ -113,6 +113,11 @@ fi
 /usr/bin/systemctl daemon-reload
 
 %changelog
+* Tue Oct 11 2016 Aaron Aichlmayr <waterfoul@gmail.com> 1.2.64
+- Bump downloaded version to 1.2.64
+- Add support for automatically downloading the .zip
+- Add travis CI support
+
 * Tue Oct 04 2016 Victor Rehorst <victor@chuma.org> 1.2.55-2
 - Fix systemd-sleep support for DisplayLink driver 1.2.58 (which is now current for v1.2)
 

--- a/displaylink.spec
+++ b/displaylink.spec
@@ -115,8 +115,6 @@ fi
 %changelog
 * Tue Oct 11 2016 Aaron Aichlmayr <waterfoul@gmail.com> 1.2.64
 - Bump downloaded version to 1.2.64
-- Add support for automatically downloading the .zip
-- Add travis CI support
 
 * Tue Oct 04 2016 Victor Rehorst <victor@chuma.org> 1.2.55-2
 - Fix systemd-sleep support for DisplayLink driver 1.2.58 (which is now current for v1.2)


### PR DESCRIPTION
Bump downloaded version to 1.2.64
Add support for automatically downloading the .zip
Add travis CI support

Fixes #4 

For this to work you will need to enable travis ci for the project and either give me access to this repo or change the api_key entry on the travis file. Once all of that is setup any time you create a release in github it will look something like [this](https://github.com/waterfoul/displaylink-rpm/releases/tag/test8). The travis file is setup to allow easy adds of other versions/distros, they only need to have a docker container in dockerhub. Once you find that add a line in the env matrix and add a script to the ci folder that matches the OS_TYPE, this script needs to install any dependencies and call make