### PR TITLE
Add Fedora 25 to the Travis build matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,7 @@ env:
     - DAEMON_VERSION=1.2.1
     - RELEASE=1
   matrix:
+  - OS_TYPE=fedora OS_VERSION=25
   - OS_TYPE=fedora OS_VERSION=24
   - OS_TYPE=fedora OS_VERSION=23
   - OS_TYPE=centos OS_VERSION=7


### PR DESCRIPTION
Fedora 25 has been out for a while. We should also build for it.