### PR TITLE
Bump version number and note new support for DL-6xxx devices.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ sudo: required
 env:
   global:
     - VERSION=1.3.43
-    - DAEMON_VERSION=1.2.65
+    - DAEMON_VERSION=1.3.52
     - RELEASE=1
   matrix:
   - OS_TYPE=fedora OS_VERSION=25

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ env:
   global:
     - VERSION=1.3.43
     - DAEMON_VERSION=1.3.52
-    - RELEASE=1
+    - RELEASE=2
   matrix:
   - OS_TYPE=fedora OS_VERSION=25
   - OS_TYPE=fedora OS_VERSION=24

--- a/Makefile
+++ b/Makefile
@@ -21,12 +21,12 @@ v$(VERSION).tar.gz:
 rpm: i386/displaylink-$(VERSION)-$(RELEASE).i386.rpm x86_64/displaylink-$(VERSION)-$(RELEASE).x86_64.rpm
 
 i386/displaylink-$(VERSION)-$(RELEASE).i386.rpm: DisplayLink\ USB\ Graphics\ Software\ for\ Ubuntu\ $(DAEMON_VERSION).zip v$(VERSION).tar.gz displaylink.spec
-	rpmbuild -bb --define "_topdir `pwd`" --define "_sourcedir `pwd`" --define "_rpmdir `pwd`" --define "_specdir `pwd`" --define "_srcrpmdir `pwd`" --define "_buildrootdir `mktemp -d /var/tmp/displayportXXXXXX`" --define "_builddir `mktemp -d /var/tmp/displayportXXXXXX`" --define "_tmppath `mktemp -d /var/tmp/displayportXXXXXX`" displaylink.spec --target=i386
+	rpmbuild -bb --define "_topdir `pwd`" --define "_sourcedir `pwd`" --define "_rpmdir `pwd`" --define "_specdir `pwd`" --define "_srcrpmdir `pwd`" --define "_buildrootdir `mktemp -d /var/tmp/displayportXXXXXX`" --define "_builddir `mktemp -d /var/tmp/displayportXXXXXX`" --define "_release $(RELEASE)" --define "_daemon_version $(DAEMON_VERSION)" --define "_version $(VERSION)" --define "_tmppath `mktemp -d /var/tmp/displayportXXXXXX`" displaylink.spec --target=i386
 
 x86_64/displaylink-$(VERSION)-$(RELEASE).x86_64.rpm: DisplayLink\ USB\ Graphics\ Software\ for\ Ubuntu\ $(DAEMON_VERSION).zip v$(VERSION).tar.gz displaylink.spec
-	rpmbuild -bb --define "_topdir `pwd`" --define "_sourcedir `pwd`" --define "_rpmdir `pwd`" --define "_specdir `pwd`" --define "_srcrpmdir `pwd`" --define "_buildrootdir `mktemp -d /var/tmp/displayportXXXXXX`" --define "_builddir `mktemp -d /var/tmp/displayportXXXXXX`" --define "_tmppath `mktemp -d /var/tmp/displayportXXXXXX`" displaylink.spec --target=x86_64
+	rpmbuild -bb --define "_topdir `pwd`" --define "_sourcedir `pwd`" --define "_rpmdir `pwd`" --define "_specdir `pwd`" --define "_srcrpmdir `pwd`" --define "_buildrootdir `mktemp -d /var/tmp/displayportXXXXXX`" --define "_builddir `mktemp -d /var/tmp/displayportXXXXXX`" --define "_release $(RELEASE)" --define "_daemon_version $(DAEMON_VERSION)" --define "_version $(VERSION)" --define "_tmppath `mktemp -d /var/tmp/displayportXXXXXX`" displaylink.spec --target=x86_64
 
 SRPM: displaylink-$(VERSION)-$(RELEASE).src.rpm
 
 displaylink-$(VERSION)-$(RELEASE).src.rpm: DisplayLink\ USB\ Graphics\ Software\ for\ Ubuntu\ $(DAEMON_VERSION).zip v$(VERSION).tar.gz displaylink.spec
-	rpmbuild -bs --define "_topdir `pwd`" --define "_sourcedir `pwd`" --define "_rpmdir `pwd`" --define "_specdir `pwd`" --define "_srcrpmdir `pwd`" --define "_buildrootdir `mktemp -d /var/tmp/displayportXXXXXX`" --define "_builddir `mktemp -d /var/tmp/displayportXXXXXX`" --define "_tmppath `mktemp -d /var/tmp/displayportXXXXXX`" displaylink.spec
+	rpmbuild -bs --define "_topdir `pwd`" --define "_sourcedir `pwd`" --define "_rpmdir `pwd`" --define "_specdir `pwd`" --define "_srcrpmdir `pwd`" --define "_buildrootdir `mktemp -d /var/tmp/displayportXXXXXX`" --define "_builddir `mktemp -d /var/tmp/displayportXXXXXX`" --define "_release $(RELEASE)" --define "_daemon_version $(DAEMON_VERSION)" --define "_version $(VERSION)" --define "_tmppath `mktemp -d /var/tmp/displayportXXXXXX`" displaylink.spec

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 VERSION=1.3.43
-DAEMON_VERSION=1.2.65
-DOWNLOAD_ID=708 # This id number comes off the link on the displaylink website
+DAEMON_VERSION=1.3.52
+DOWNLOAD_ID=744 # This id number comes off the link on the displaylink website
 RELEASE=1
 
 .PHONY: srpm rpm

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 VERSION=1.3.43
 DAEMON_VERSION=1.3.52
 DOWNLOAD_ID=744 # This id number comes off the link on the displaylink website
-RELEASE=1
+RELEASE=2
 
 .PHONY: srpm rpm
 
@@ -26,7 +26,7 @@ i386/displaylink-$(VERSION)-$(RELEASE).i386.rpm: DisplayLink\ USB\ Graphics\ Sof
 x86_64/displaylink-$(VERSION)-$(RELEASE).x86_64.rpm: DisplayLink\ USB\ Graphics\ Software\ for\ Ubuntu\ $(DAEMON_VERSION).zip v$(VERSION).tar.gz displaylink.spec
 	rpmbuild -bb --define "_topdir `pwd`" --define "_sourcedir `pwd`" --define "_rpmdir `pwd`" --define "_specdir `pwd`" --define "_srcrpmdir `pwd`" --define "_buildrootdir `mktemp -d /var/tmp/displayportXXXXXX`" --define "_builddir `mktemp -d /var/tmp/displayportXXXXXX`" --define "_tmppath `mktemp -d /var/tmp/displayportXXXXXX`" displaylink.spec --target=x86_64
 
-srpm: displaylink-$(VERSION)-$(RELEASE).src.rpm
+SRPM: displaylink-$(VERSION)-$(RELEASE).src.rpm
 
 displaylink-$(VERSION)-$(RELEASE).src.rpm: DisplayLink\ USB\ Graphics\ Software\ for\ Ubuntu\ $(DAEMON_VERSION).zip v$(VERSION).tar.gz displaylink.spec
 	rpmbuild -bs --define "_topdir `pwd`" --define "_sourcedir `pwd`" --define "_rpmdir `pwd`" --define "_specdir `pwd`" --define "_srcrpmdir `pwd`" --define "_buildrootdir `mktemp -d /var/tmp/displayportXXXXXX`" --define "_builddir `mktemp -d /var/tmp/displayportXXXXXX`" --define "_tmppath `mktemp -d /var/tmp/displayportXXXXXX`" displaylink.spec

--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@ DisplayLink RPM
 This is the recipe for building the [DisplayLink driver][displaylink]
 in a RPM package for Fedora and CentOS. This driver supports the following
 device families:
+ - DL-6xxx
  - DL-5xxx
  - DL-41xx
  - DL-3xxx

--- a/README.md
+++ b/README.md
@@ -55,17 +55,17 @@ We manage three different upstream numbers for versioning:
 
 These variables need to be changed in the following places:
 
-- displaylink.spec
-  - `%{daemon_version}` is the DisplayLinkManager version
-  - `Version:` is currently the evdi driver version
 - Makefile
-  - `DAEMON_VERSION` is the advertised package version
-  - `VERSION` is the same version as the specfile `Version:`
+  - `DAEMON_VERSION` is the DisplayLinkManager version
+  - `VERSION` is currently the evdi driver version
   - `DOWNLOAD_ID` is the `?download_id=` query parameter in
     DisplayLink website to download the zip
 - .travis.yml
   - `VERSION` is the same as in the Makefile
   - `DAEMON_VERSION` is the same version as in Makefile
+
+Also, please update the changelog at the bottom of the
+displaylink.spec file.
 
 
 Packaging change

--- a/displaylink.spec
+++ b/displaylink.spec
@@ -1,10 +1,10 @@
 %global debug_package %{nil}
-%define daemon_version 1.2.65
+%define daemon_version 1.3.52
 
 Name:		displaylink
 Version:	1.3.43
 Release:	1
-Summary:	DisplayLink VGA/HDMI driver for DL-5xxx, DL-41xx and DL-3xxx adapters
+Summary:	DisplayLink VGA/HDMI driver for DL-6xxx, DL-5xxx, DL-41xx and DL-3xxx adapters
 
 Group:		User Interface/X Hardware Support
 License:	GPL v2.0, LGPL v2.1 and Proprietary
@@ -20,9 +20,9 @@ BuildRequires:	libdrm-devel
 Requires:	dkms, kernel > 4.7, kernel-devel > 4.7
 
 %description
-This adds support for HDMI/VGA adapters built upon the DisplayLink DL-5xxx,
-DL-41xx and DL-3xxx series of chipsets. This includes numerous docking
-stations, USB monitors, and USB adapters.
+This adds support for HDMI/VGA adapters built upon the DisplayLink DL-6xxx,
+DL-5xxx, DL-41xx and DL-3xxx series of chipsets. This includes numerous
+docking stations, USB monitors, and USB adapters.
 
 %define logfile /var/log/displaylink/%{name}.log
 
@@ -113,6 +113,10 @@ fi
 /usr/bin/systemctl daemon-reload
 
 %changelog
+* Sun Feb 19 2017 Richard Hofer <rofer@rofer.me> 1.3.52
+- Bump downloaded version to 1.3.52
+- Note support for DL-6xxx devices
+
 * Tue Oct 11 2016 Aaron Aichlmayr <waterfoul@gmail.com> 1.2.64
 - Bump downloaded version to 1.2.64
 

--- a/displaylink.spec
+++ b/displaylink.spec
@@ -1,9 +1,8 @@
 %global debug_package %{nil}
-%define daemon_version 1.3.52
 
 Name:		displaylink
-Version:	1.3.43
-Release:	1
+Version:	%{_version}
+Release:	%{_release}
 Summary:	DisplayLink VGA/HDMI driver for DL-6xxx, DL-5xxx, DL-41xx and DL-3xxx adapters
 
 Group:		User Interface/X Hardware Support
@@ -13,7 +12,7 @@ Source1:	displaylink.service
 Source2:	99-displaylink.rules
 Source3:        displaylink-sleep-extractor.sh
 # From http://www.displaylink.com/downloads/ubuntu.php
-Source4:	DisplayLink USB Graphics Software for Ubuntu %{daemon_version}.zip
+Source4:	DisplayLink USB Graphics Software for Ubuntu %{_daemon_version}.zip
 ExclusiveArch:	i386 x86_64
 
 BuildRequires:	libdrm-devel
@@ -32,8 +31,8 @@ cd evdi-%{version}
 sed -i 's/\r//' README.md
 
 unzip "%{SOURCE4}"
-chmod +x displaylink-driver-%{daemon_version}.run
-./displaylink-driver-%{daemon_version}.run --noexec --keep
+chmod +x displaylink-driver-%{_daemon_version}.run
+./displaylink-driver-%{_daemon_version}.run --noexec --keep
 # This creates a displaylink-driver-$version subdirectory
 
 %build
@@ -62,7 +61,7 @@ cp evdi-%{version}/library/libevdi.so $RPM_BUILD_ROOT/usr/libexec/displaylink
 # Don't copy libusb-1.0.so.0.1.0 it's already shipped by libusbx
 # Don't copy libevdi.so, we compiled it from source
 
-cd evdi-%{version}/displaylink-driver-%{daemon_version}
+cd evdi-%{version}/displaylink-driver-%{_daemon_version}
 
 cp LICENSE ../..
 


### PR DESCRIPTION
I think we need to raise the version in the Makefile. Right now it's set to match the evdi driver as the README says, but since the evdi driver hasn't changed since the last release these packages won't appear new.

A simple fix would be to append the DisplayLink Download ID to the version making this 1.3.43.744. Does this sound reasonable?