### PR TITLE
Disable PageFilp for xorg using modesetting driver

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ env:
   global:
     - VERSION=1.4.1
     - DAEMON_VERSION=1.3.54
-    - RELEASE=2
+    - RELEASE=3
   matrix:
   - OS_TYPE=fedora OS_VERSION=25
   - OS_TYPE=fedora OS_VERSION=24
@@ -32,7 +32,7 @@ deploy:
     tags: true
   api_key:
     secure: faqfSs9slgmmDOquGF4qBu74gzClZ6Mr6aTn0wb8IWLQdfLXZ8kNufQU5qgMI+xOZBBAq9TAVAfpJ75MGoBkJC9xUFoA4E+i935ir/TPjy74KPoriHfg2rtKJW0P+Ma9BbG3NHs60/dIZKwMoXPR8YcTYQ6vNwckAxoHeXNfNmhoYNrLHgXEhKmPxWNFO/x4gLtA/w5bL1TR5TTHnFA7bmmHxXpIw0RH8zISYysWStOthZSyf7BBnyArM46kX1ez5gJQ/2RHHOiYp+KhzzLCDVIMDdXcCf18kxuSNiqbAkguSmhoQA53OUAuvcsBxwhm/zEBuhuhuZBGgZkArjuWIOh36bdCX1XfJLwOKiqvU3Gz99SDAHxc9VDZmTLXyUOIxu7BI8+1VSPUZT/0n9G7LUJzE3LgnuNtCcXP0LWQbt3cLyrKYVWZPtdGwQ+Q6EHM61MM5aGZBl+olHuCRMvkRWJYks88G+zWKSbwvRCwOolJNoKLvdeU2gqhia6Hfp0UHTZnvJRmvhrjNxrD5jXnL05fcr5h2g9C0uVCQAJNpC9qHRFk/WskGVrwRhlpSHME8ugawNsr5+/qzY4SZncbNoqn/iOTQE0wxNtdNNIYjofrPKsRMGErkOZzWFTzlF/2bdb2gOo2jU4QUCJwshOAv0gKJ3r1WJDaodKYXqasASA=
-  file: 
+  file:
     - ${OS_TYPE}-${OS_VERSION}-displaylink-${VERSION}-${RELEASE}.src.rpm
     - ${OS_TYPE}-${OS_VERSION}-displaylink-${VERSION}-${RELEASE}.x86_64.rpm
     - ${OS_TYPE}-${OS_VERSION}-displaylink-${VERSION}-${RELEASE}.i386.rpm

--- a/20-displaylink.conf
+++ b/20-displaylink.conf
@@ -1,0 +1,38 @@
+Section "Device"
+    Identifier "intel"
+    Driver "modesetting"
+    Option "kmsdev" "/dev/dri/card0"
+    Option "PageFlip" "off"
+    Option "SWCursor" "on"
+    Option "ShadowFB" "true"
+EndSection
+
+Section "Device"
+    Identifier "USB3"
+    BusID "USB"
+    Driver "modesetting"
+    Option "kmsdev" "/dev/dri/card1"
+    Option "PageFlip" "off"
+    Option "SWCursor" "on"
+    Option "ShadowFB" "true"
+EndSection
+
+Section "Device"
+    Identifier "USB3"
+    BusID "USB"
+    Driver "modesetting"
+    Option "kmsdev" "/dev/dri/card2"
+    Option "PageFlip" "off"
+    Option "SWCursor" "on"
+    Option "ShadowFB" "true"
+EndSection
+
+Section "Device"
+    Identifier "USB3"
+    BusID "USB"
+    Driver "modesetting"
+    Option "kmsdev" "/dev/dri/card3"
+    Option "PageFlip" "off"
+    Option "SWCursor" "on"
+    Option "ShadowFB" "true"
+EndSection

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 VERSION=1.4.1
 DAEMON_VERSION=1.3.54
 DOWNLOAD_ID=993 # This id number comes off the link on the displaylink website
-RELEASE=2
+RELEASE=3
 
 .PHONY: srpm rpm
 

--- a/displaylink.spec
+++ b/displaylink.spec
@@ -13,6 +13,7 @@ Source2:	99-displaylink.rules
 Source3:        displaylink-sleep-extractor.sh
 # From http://www.displaylink.com/downloads/ubuntu.php
 Source4:	DisplayLink USB Graphics Software for Ubuntu %{_daemon_version}.zip
+Source5:    20-displaylink.conf
 ExclusiveArch:	i386 x86_64
 
 BuildRequires:	libdrm-devel
@@ -47,6 +48,7 @@ mkdir -p $RPM_BUILD_ROOT/usr/libexec/displaylink/	\
 	$RPM_BUILD_ROOT/usr/lib/systemd/system/		\
 	$RPM_BUILD_ROOT/usr/lib/systemd/system-sleep	\
 	$RPM_BUILD_ROOT/etc/udev/rules.d/		\
+	$RPM_BUILD_ROOT/etc/X11/xorg.conf.d/		\
 	$RPM_BUILD_ROOT/var/log/displaylink/
 
 # Kernel driver sources
@@ -79,6 +81,7 @@ cp -a ella-dock-release.spkg firefly-monitor-release.spkg $RPM_BUILD_ROOT/usr/li
 # systemd/udev
 cp -a %{SOURCE1} $RPM_BUILD_ROOT/usr/lib/systemd/system/
 cp -a %{SOURCE2} $RPM_BUILD_ROOT/etc/udev/rules.d/
+cp -a %{SOURCE5} $RPM_BUILD_ROOT/etc/X11/xorg.conf.d/
 
 # pm-util
 bash %{SOURCE3} displaylink-installer.sh > $RPM_BUILD_ROOT/usr/lib/systemd/system-sleep/displaylink.sh
@@ -96,6 +99,7 @@ done
 /usr/lib/systemd/system/displaylink.service
 /usr/lib/systemd/system-sleep/displaylink.sh
 /etc/udev/rules.d/99-displaylink.rules
+/etc/X11/xorg.conf.d/20-displaylink.conf
 %dir /usr/src/evdi-%{version}
 /usr/src/evdi-%{version}/*
 %dir /usr/libexec/displaylink
@@ -112,6 +116,9 @@ fi
 /usr/bin/systemctl daemon-reload
 
 %changelog
+* Tue Jul 11 2017 Kahlil Hodgson <kahlil.hodgson999@gmail.com> 1.1.4-3
+- Disable PageFlip if xorg is using modesetting driver
+
 * Sat Jul 8 2017 Alan Halama <alhalama@gmail.com> 1.3.54
 - Bump downloaded version to 1.3.54
 


### PR DESCRIPTION
Adds a xorg config file to disable page flipping on systems that use the modesetting driver.

The issue is discussed in https://github.com/DisplayLink/evdi/issues/92 and the basic workaround is described in http://support.displaylink.com/knowledgebase/articles/1181623.

The old intel driver workaround does not seem to work for Fedora 26 so I've opted for disabling PageFlip 
for the primary and up to 3 additional displays.

We can drop this once either xorg supports page flipping on slave outputs or DisplayLink starts supporting Wayland :-)
