### PR TITLE
Systemd sleep perms

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ env:
   global:
     - VERSION=1.4.1
     - DAEMON_VERSION=1.3.54
-    - RELEASE=3
+    - RELEASE=4
   matrix:
   - OS_TYPE=fedora OS_VERSION=26
   - OS_TYPE=fedora OS_VERSION=25

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 VERSION=1.4.1
 DAEMON_VERSION=1.3.54
 DOWNLOAD_ID=993 # This id number comes off the link on the displaylink website
-RELEASE=3
+RELEASE=4
 
 .PHONY: srpm rpm
 

--- a/displaylink.spec
+++ b/displaylink.spec
@@ -117,6 +117,9 @@ fi
 /usr/bin/systemctl daemon-reload
 
 %changelog
+* Tue Jul 11 2017 Kahlil Hodgson <kahlil.hodgson999@gmail.com> 1.1.4-4
+- Give systemd sleep script exec permissions
+
 * Tue Jul 11 2017 Kahlil Hodgson <kahlil.hodgson999@gmail.com> 1.1.4-3
 - Disable PageFlip if xorg is using modesetting driver
 

--- a/displaylink.spec
+++ b/displaylink.spec
@@ -117,7 +117,7 @@ fi
 /usr/bin/systemctl daemon-reload
 
 %changelog
-* Tue Jul 11 2017 Kahlil Hodgson <kahlil.hodgson999@gmail.com> 1.1.4-4
+* Wed Jul 26 2017 Kahlil Hodgson <kahlil.hodgson999@gmail.com> 1.1.4-4
 - Give systemd sleep script exec permissions
 
 * Tue Jul 11 2017 Kahlil Hodgson <kahlil.hodgson999@gmail.com> 1.1.4-3

--- a/displaylink.spec
+++ b/displaylink.spec
@@ -10,7 +10,7 @@ License:	GPL v2.0, LGPL v2.1 and Proprietary
 Source0:	https://github.com/DisplayLink/evdi/archive/v%{version}.tar.gz
 Source1:	displaylink.service
 Source2:	99-displaylink.rules
-Source3:        displaylink-sleep-extractor.sh
+Source3:    displaylink-sleep-extractor.sh
 # From http://www.displaylink.com/downloads/ubuntu.php
 Source4:	DisplayLink USB Graphics Software for Ubuntu %{_daemon_version}.zip
 Source5:    20-displaylink.conf
@@ -86,6 +86,7 @@ cp -a %{SOURCE5} $RPM_BUILD_ROOT/etc/X11/xorg.conf.d/
 # pm-util
 bash %{SOURCE3} displaylink-installer.sh > $RPM_BUILD_ROOT/usr/lib/systemd/system-sleep/displaylink.sh
 
+chmod +x $RPM_BUILD_ROOT/usr/lib/systemd/system-sleep/displaylink.sh
 
 %post
 /usr/bin/systemctl daemon-reload


### PR DESCRIPTION
the systemd sleep script was not being run on PM events because it did not have appropriate execute permissions. This patch should fix that. 

Also includes a minor tweak to whitespace to keep rpmlint happy. 