### PR TITLE
Service restart on upgrade

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ env:
   global:
     - VERSION=1.4.1
     - DAEMON_VERSION=1.3.54
-    - RELEASE=4
+    - RELEASE=5
   matrix:
   - OS_TYPE=fedora OS_VERSION=26
   - OS_TYPE=fedora OS_VERSION=25

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 VERSION=1.4.1
 DAEMON_VERSION=1.3.54
 DOWNLOAD_ID=993 # This id number comes off the link on the displaylink website
-RELEASE=4
+RELEASE=5
 
 .PHONY: srpm rpm
 

--- a/displaylink.spec
+++ b/displaylink.spec
@@ -90,7 +90,7 @@ chmod +x $RPM_BUILD_ROOT/usr/lib/systemd/system-sleep/displaylink.sh
 
 %post
 # The displaylink service may crash as dkms rebuilds the module
-/usr/bin/systemctl stop displaylink.service
+//usr/bin/systemctl -q is-active displaylink.service && usr/bin/systemctl stop displaylink.service
 /usr/bin/systemctl daemon-reload
 /usr/bin/systemctl -q is-enabled dkms.service || /usr/bin/systemctl enable dkms.service
 for kernel in $(rpm -q kernel --queryformat '%{VERSION}-%{RELEASE}.%{ARCH}\n') ;do

--- a/displaylink.spec
+++ b/displaylink.spec
@@ -90,7 +90,7 @@ chmod +x $RPM_BUILD_ROOT/usr/lib/systemd/system-sleep/displaylink.sh
 
 %post
 # The displaylink service may crash as dkms rebuilds the module
-/usr/bin/systemctl -q is-active displaylink.service && usr/bin/systemctl stop displaylink.service
+/usr/bin/systemctl -q is-active displaylink.service && /usr/bin/systemctl stop displaylink.service
 /usr/bin/systemctl daemon-reload
 /usr/bin/systemctl -q is-enabled dkms.service || /usr/bin/systemctl enable dkms.service
 for kernel in $(rpm -q kernel --queryformat '%{VERSION}-%{RELEASE}.%{ARCH}\n') ;do

--- a/displaylink.spec
+++ b/displaylink.spec
@@ -90,7 +90,7 @@ chmod +x $RPM_BUILD_ROOT/usr/lib/systemd/system-sleep/displaylink.sh
 
 %post
 # The displaylink service may crash as dkms rebuilds the module
-//usr/bin/systemctl -q is-active displaylink.service && usr/bin/systemctl stop displaylink.service
+/usr/bin/systemctl -q is-active displaylink.service && usr/bin/systemctl stop displaylink.service
 /usr/bin/systemctl daemon-reload
 /usr/bin/systemctl -q is-enabled dkms.service || /usr/bin/systemctl enable dkms.service
 for kernel in $(rpm -q kernel --queryformat '%{VERSION}-%{RELEASE}.%{ARCH}\n') ;do


### PR DESCRIPTION
Stop the displaylink service before the dkms rebuild and restart it after. This should make upgrades cleaner and more robust.