### PR TITLE
Use github api to determine upstream versions

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,21 +7,6 @@ DOWNLOAD_ID    := 993    # This id number comes off the link on the displaylink 
 VERSION        := 1.4.1
 RELEASE        := 5
 
-EDVI_GITHUB := https://api.github.com/repos/DisplayLink/evdi
-
-define get_latest_prerelease
-	curl -s $(EDVI_GITHUB)/releases?per_page=1 \
-		-H "Accept: application/vnd.github.full+json" |\
-		grep tag_name | sed s/[^0-9\.]//g
-endef
-
-define get_devel_date
-	curl -s $(EDVI_GITHUB)/branches/devel \
-		-H "Accept: application/vnd.github.full+json" |\
-		grep date | head -1 | cut -d: -f 2- |\
-		sed s/[^0-9TZ]//g
-endef
-
 #
 # Dependencies
 #
@@ -47,6 +32,25 @@ x86_64_RPM := x86_64/displaylink-$(VERSION)-$(RELEASE).x86_64.rpm
 SRPM       := displaylink-$(VERSION)-$(RELEASE).src.rpm
 
 TARGETS    := $(i386_RPM) $(x86_64_RPM) $(SRPM)
+
+#
+# Upstream checks
+#
+
+EDVI_GITHUB := https://api.github.com/repos/DisplayLink/evdi
+
+define get_latest_prerelease
+	curl -s $(EDVI_GITHUB)/releases?per_page=1 \
+		-H "Accept: application/vnd.github.full+json" |\
+		grep tag_name | sed s/[^0-9\.]//g
+endef
+
+define get_devel_date
+	curl -s $(EDVI_GITHUB)/branches/devel \
+		-H "Accept: application/vnd.github.full+json" |\
+		grep date | head -1 | cut -d: -f 2- |\
+		sed s/[^0-9TZ]//g
+endef
 
 #
 # PHONY targets

--- a/Makefile
+++ b/Makefile
@@ -2,45 +2,60 @@
 # Versions
 #
 
-VERSION        = 1.4.1
-DAEMON_VERSION = 1.3.54
-DOWNLOAD_ID    = 993    # This id number comes off the link on the displaylink website
-RELEASE        = 5
+DAEMON_VERSION := 1.3.54
+DOWNLOAD_ID    := 993    # This id number comes off the link on the displaylink website
+RELEASE        := 5
 
-# We dont want recursive expansion for the following
-RAWHIDE       := $(RELEASE).rawhide.$(shell date "+%Y%m%d")
+EDVI_GITHUB := https://api.github.com/repos/DisplayLink/evdi
+
+define get_latest_prerelease =
+	curl -s $(EDVI_GITHUB)/releases?per_page=1 \
+		-H "Accept: application/vnd.github.full+json" |\
+		grep tag_name | sed s/[^0-9\.]//g
+endef
+
+define get_devel_date =
+	curl -s $(EDVI_GITHUB)/branches/devel \
+		-H "Accept: application/vnd.github.full+json" |\
+		grep date | head -1 | cut -d: -f 2- |\
+		sed s/[^0-9TZ]//g
+endef
+
+VERSION     := $(shell $(get_latest_prerelease))
+DEVEL_DATE  := $(shell $(get_devel_date))
+RAWHIDE     := $(RELEASE).rawhide.$(DEVEL_DATE)
 
 #
 # Dependencies
 #
 
-DAEMON_PKG = DisplayLink\ USB\ Graphics\ Software\ for\ Ubuntu\ $(DAEMON_VERSION).zip
-EVDI_PKG   = v$(VERSION).tar.gz
-SPEC_FILE  = displaylink.spec
+DAEMON_PKG := DisplayLink\ USB\ Graphics\ Software\ for\ Ubuntu\ $(DAEMON_VERSION).zip
+EVDI_PKG   := v$(VERSION).tar.gz
+SPEC_FILE  := displaylink.spec
 
 # The following is a little clunky, but we need to ensure the resulting
-# tarball expands the same way as upstream
-EVDI_DEVEL_BRANCH = devel
-EVDI_DEVEL_BASE_DIR = /var/tmp
-EVDI_DEVEL = $(EVDI_DEVEL_BASE_DIR)/evdi-$(VERSION)
+# tarball expands the same way as the upstream tarball
+EVDI_DEVEL_BRANCH   := devel
+EVDI_DEVEL_BASE_DIR := /var/tmp
+EVDI_DEVEL          := $(EVDI_DEVEL_BASE_DIR)/evdi-$(VERSION)
 
-BUILD_DEPS = $(DAEMON_PKG) $(EVDI_PKG) $(SPEC_FILE)
+BUILD_DEPS := $(DAEMON_PKG) $(EVDI_PKG) $(SPEC_FILE)
 
 #
 # Targets
 #
 
-i386_RPM   = i386/displaylink-$(VERSION)-$(RELEASE).i386.rpm
-x86_64_RPM = x86_64/displaylink-$(VERSION)-$(RELEASE).x86_64.rpm
-SRPM       = displaylink-$(VERSION)-$(RELEASE).src.rpm
+i386_RPM   := i386/displaylink-$(VERSION)-$(RELEASE).i386.rpm
+x86_64_RPM := x86_64/displaylink-$(VERSION)-$(RELEASE).x86_64.rpm
+SRPM       := displaylink-$(VERSION)-$(RELEASE).src.rpm
 
-TARGETS    = $(i386_RPM) $(x86_64_RPM) $(SRPM)
+TARGETS    := $(i386_RPM) $(x86_64_RPM) $(SRPM)
 
 #
 # PHONY targets
 #
 
-.PHONY: all rpm srpm devel rawhide clean clean-rawhide clean-mainline
+.PHONY: all rpm srpm devel rawhide clean clean-rawhide clean-mainline versions
 
 all: $(TARGETS)
 
@@ -62,6 +77,12 @@ clean-mainline:
 	rm -rf $(TARGETS) $(EVDI_DEVEL) $(EVDI_PKG)
 
 clean: clean-mainline clean-rawhide
+
+# for testing our version construction
+versions:
+	@echo $(VERSION)
+	@echo $(DEVEL_DATE)
+	@echo $(RAWHIDE)
 
 #
 # Real targets


### PR DESCRIPTION
Use the GitHub API to determine:
1. The latest released version of EVDI (including prereleases)
2. The date of the last commit to the devel branch (used for versioning rawhide builds)

Caveat: This can slow the build a bit depending on GitHub load and rate limiting.