### PR TITLE
display link website now requires https

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -107,7 +107,7 @@ $(EVDI_DEVEL):
 
 $(DAEMON_PKG):
 	wget --post-data="fileId=$(DOWNLOAD_ID)&accept_submit=Accept" -O $(DAEMON_PKG) \
-		 http://www.displaylink.com/downloads/file?id=$(DOWNLOAD_ID)
+		 https://www.displaylink.com/downloads/file?id=$(DOWNLOAD_ID)
 
 $(EVDI_PKG):
 	wget -O v$(VERSION).tar.gz \


### PR DESCRIPTION
Using the http url results in an HTML response.

Using a https url results in retrieving the correct file.

### wget with HTTP
``` wget --post-data="fileId=1261&accept_submit=Accept" -O test.zip http://www.displaylink.com/downloads/file?id=1261
--2018-11-16 23:34:29--  http://www.displaylink.com/downloads/file?id=1261
Resolving www.displaylink.com (www.displaylink.com)... 34.252.223.12, 54.76.51.192, 52.208.143.240, ...
Connecting to www.displaylink.com (www.displaylink.com)|34.252.223.12|:80... connected.
HTTP request sent, awaiting response... 301 Moved Permanently
Location: https://www.displaylink.com/downloads/file?id=1261 [following]
--2018-11-16 23:34:29--  https://www.displaylink.com/downloads/file?id=1261
Connecting to www.displaylink.com (www.displaylink.com)|34.252.223.12|:443... connected.
HTTP request sent, awaiting response... 200 OK
Length: unspecified [text/html]
Saving to: ‘test.zip’

test.zip                      [ <=>                                ]  30.48K  --.-KB/s    in 0.003s  

2018-11-16 23:34:30 (11.1 MB/s) - ‘test.zip’ saved [31216]
```

### Results in raw html
``` head test.zip
<!DOCTYPE html>
<!--[if IE 9]><html lang="en" class="ie9"><![endif]-->
<!--[if !IE 9]><html lang="en"><![endif]-->
<html lang="en-GB">
  <head>
	<meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
	<meta name="charset" content="utf-8" />
	<meta http-equiv="X-UA-Compatible" content="IE=edge" />
	<meta name="viewport" content="width=device-width, initial-scale=1" />
	<title>Download: DisplayLink USB Graphics Software for Ubuntu (4.4)</title>
```

### wget with HTTPS
``` wget --post-data="fileId=1261&accept_submit=Accept" -O test.zip https://www.displaylink.com/downloads/file?id=1261
--2018-11-16 23:31:03--  https://www.displaylink.com/downloads/file?id=1261
Resolving www.displaylink.com (www.displaylink.com)... 52.208.143.240, 54.76.51.192, 54.72.7.162, ...
Connecting to www.displaylink.com (www.displaylink.com)|52.208.143.240|:443... connected.
HTTP request sent, awaiting response... 303 See Other
Location: http://assets.displaylink.com/live/downloads/software/f1261_DisplayLink%20USB%20Graphics%20Software%20for%20Ubuntu%204.4.zip?AWSAccessKeyId=AKIAJHGQWPVXWHEDJUEA&Expires=1542429828&Signature=HK55yt02TrwA0Y7cZJcr%2BkZtPAU%3D [following]
--2018-11-16 23:31:04--  http://assets.displaylink.com/live/downloads/software/f1261_DisplayLink%20USB%20Graphics%20Software%20for%20Ubuntu%204.4.zip?AWSAccessKeyId=AKIAJHGQWPVXWHEDJUEA&Expires=1542429828&Signature=HK55yt02TrwA0Y7cZJcr%2BkZtPAU%3D
Resolving assets.displaylink.com (assets.displaylink.com)... 52.218.16.156
Connecting to assets.displaylink.com (assets.displaylink.com)|52.218.16.156|:80... connected.
HTTP request sent, awaiting response... 200 OK
Length: 17626360 (17M) [application/octet-stream]
Saving to: ‘test.zip’

test.zip                  100%[===================================>]  16.81M  4.74MB/s    in 5.4s    

2018-11-16 23:31:10 (3.13 MB/s) - ‘test.zip’ saved [17626360/17626360]
```
