### PR TITLE
Fix release version in rawhide targets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -46,6 +46,10 @@ define get_latest_prerelease
 		grep tag_name | sed s/[^0-9\.]//g
 endef
 
+define get_release_version
+        echo -e "$(RELEASE)" | tr -d '[:space:]'
+endef
+
 define get_devel_date
 	curl -s $(EDVI_GITHUB)/branches/devel \
 		-H "Accept: application/vnd.github.full+json" |\
@@ -71,13 +75,11 @@ devel: $(EVDI_DEVEL)
 
 rawhide:
 	@echo Checking last upstream commit date...
-	@rawhide=$(RELEASE).rawhide.`$(get_devel_date)`; \
-	$(MAKE) RELEASE=$$rawhide devel all
+	$(MAKE) RELEASE="`$(get_release_version)`.rawhide.`$(get_devel_date)`" devel all
 
 clean-rawhide:
 	@echo Checking last upstream commit date...
-	@rawhide=$(RELEASE).rawhide.`$(get_devel_date)`; \
-	$(MAKE) RELEASE=$$rawhide clean-mainline
+	$(MAKE) RELEASE="`$(get_release_version)`.rawhide.`$(get_devel_date)`" clean-mainline
 
 clean-mainline:
 	rm -rf $(TARGETS) $(EVDI_DEVEL) $(EVDI_PKG)


### PR DESCRIPTION
Fixes empty release version for rawhide targets, e.g.:

    make rawhide
    Checking last upstream commit date...
    /bin/sh: .rawhide.20180830T065739Z: command not found
    ...
    rpmbuild -bb --define "_topdir `pwd`" --define "_sourcedir `pwd`" --define "_rpmdir `pwd`" --define "_specdir `pwd`" --define "_srcrpmdir `pwd`" --define "_buildrootdir `mktemp -d /var/tmp/displayportXXXXXX`" --define "_builddir `mktemp -d /var/tmp/displayportXXXXXX`" --define "_release " --define "_daemon_version 4.4.24" --define "_version 1.5.1" --define "_tmppath `mktemp -d /var/tmp/displayportXXXXXX`"  displaylink.spec --target=i386
    error: Macro %_release has empty body
    make[1]: *** [Makefile:134: i386/displaylink-1.5.1-.i386.rpm] Error 1

