### PR TITLE
Update DisplayLink and Evdi

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,9 +2,9 @@ language: generic
 sudo: required
 env:
   global:
-    - VERSION=1.5.1
-    - DAEMON_VERSION=4.4.24
-    - RELEASE=2
+    - VERSION=1.6.0
+    - DAEMON_VERSION=5.1.26
+    - RELEASE=1
   matrix:
   - OS_TYPE=fedora OS_VERSION=29
   - OS_TYPE=fedora OS_VERSION=28

--- a/Makefile
+++ b/Makefile
@@ -2,10 +2,10 @@
 # Versions
 #
 
-DAEMON_VERSION := 4.4.24
-DOWNLOAD_ID    := 1261    # This id number comes off the link on the displaylink website
-VERSION        := 1.5.1
-RELEASE        := 2 
+DAEMON_VERSION := 5.1.26
+DOWNLOAD_ID    := 1304    # This id number comes off the link on the displaylink website
+VERSION        := 1.6.0
+RELEASE        := 1
 
 #
 # Dependencies

--- a/displaylink.spec
+++ b/displaylink.spec
@@ -126,6 +126,10 @@ fi
 /usr/bin/systemctl daemon-reload
 
 %changelog
+* Tue Feb 19 2019 Michael L. Young <elgueromexicano@gmail.com> 1.6.0-1
+- Update DisplayLink Manager to 5.1.26
+- Update evdi to 1.6.0
+
 * Tue Dec 11 2018 Orsiris de Jong <ozy@netpower.fr> 1.5.1-2
 - Add make and gcc-c++ build requirements
 


### PR DESCRIPTION
This commit will allow us to create RPM based on:
  * DisplayLink Manager 5.1.26
  * evdi 1.6.0

issue #83