### PR TITLE
Reinstall evdi when kernel update is installed.

### DIFF
--- a/displaylink.spec
+++ b/displaylink.spec
@@ -106,7 +106,7 @@ chmod +x $RPM_BUILD_ROOT/usr/lib/systemd/system-sleep/displaylink.sh
 
 %triggerin -- kernel
 NEWEST_KERNEL=$(rpm -q kernel|sort -V|head -1|cut -d- -f2-)
-/sbin/dkms install evdi/%{version} ${NEWEST_KERNEL}
+/sbin/dkms install evdi/%{version} ${NEWEST_KERNEL} >>%{logfile} 2>&1
 
 %files
 %doc LICENSE

--- a/displaylink.spec
+++ b/displaylink.spec
@@ -104,6 +104,10 @@ chmod +x $RPM_BUILD_ROOT/usr/lib/systemd/system-sleep/displaylink.sh
 /sbin/dkms install evdi/%{version} >> %{logfile} 2>&1
 /usr/bin/systemctl start displaylink.service
 
+%triggerin -- kernel
+NEWEST_KERNEL=$(rpm -q kernel|sort -V|head -1|cut -d- -f2-)
+/sbin/dkms install evdi/%{version} ${NEWEST_KERNEL}
+
 %files
 %doc LICENSE
 /usr/lib/systemd/system/displaylink.service


### PR DESCRIPTION
After a kernel update is installed, the displaylink manager fails on boot because the evdi module is no longer present for the running kernel. This change ensures that the module is installed whenever the kernel is updated. (It will not handle the case where the new kernel is not the newest one, but I feel that's a rare case; similarly, it doesn't handle installing the module for any intermediate kernels that may already exist.) This may go away when #81 is resolved, but in the meantime it should make life easier for those who regularly apply distribution updates.