### PR TITLE
Update evdi To The Latest Release

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,9 +2,9 @@ language: generic
 sudo: required
 env:
   global:
-    - VERSION=1.6.0
+    - VERSION=1.6.1
     - DAEMON_VERSION=5.1.26
-    - RELEASE=2
+    - RELEASE=1
   matrix:
   - OS_TYPE=fedora OS_VERSION=29
   - OS_TYPE=fedora OS_VERSION=28

--- a/Makefile
+++ b/Makefile
@@ -4,8 +4,8 @@
 
 DAEMON_VERSION := 5.1.26
 DOWNLOAD_ID    := 1304    # This id number comes off the link on the displaylink website
-VERSION        := 1.6.0
-RELEASE        := 2
+VERSION        := 1.6.1
+RELEASE        := 1
 
 #
 # Dependencies

--- a/displaylink.spec
+++ b/displaylink.spec
@@ -130,6 +130,9 @@ fi
 /usr/bin/systemctl daemon-reload
 
 %changelog
+* Wed May 08 2019 Michael L. Young <elgueromexicano@gmail.com> 1.6.1-1
+- Update evdi to 1.6.1
+
 * Mon Mar 25 2019 Peter Janes <peter.janes@autodata.net> 1.6.0-2
 - Add trigger on kernel postinstall to compile evdi via dkms for the new version
 


### PR DESCRIPTION
evdi-1.6.1 has been released.  This patch updates the RPM build to use it.