### PR TITLE
Update evdi to version 1.6.2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ language: generic
 sudo: required
 env:
   global:
-    - VERSION=1.6.1
+    - VERSION=1.6.2
     - DAEMON_VERSION=5.1.26
     - RELEASE=1
   matrix:

--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@
 
 DAEMON_VERSION := 5.1.26
 DOWNLOAD_ID    := 1304    # This id number comes off the link on the displaylink website
-VERSION        := 1.6.1
+VERSION        := 1.6.2
 RELEASE        := 1
 
 #

--- a/displaylink.spec
+++ b/displaylink.spec
@@ -130,6 +130,9 @@ fi
 /usr/bin/systemctl daemon-reload
 
 %changelog
+* Mon Jul 08 2019 Michael L. Young <elgueromexicano@gmail.com> 1.6.2-1
+- Update evdi to 1.6.2
+
 * Wed May 08 2019 Michael L. Young <elgueromexicano@gmail.com> 1.6.1-1
 - Update evdi to 1.6.1
 


### PR DESCRIPTION
This patch updates the RPM build to use the latest version of evdi which is 1.6.2.