### PR TITLE
Updating to latest Displaylink driver 5.2.14

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,8 +3,8 @@ sudo: required
 env:
   global:
     - VERSION=1.6.2
-    - DAEMON_VERSION=5.1.26
-    - RELEASE=1
+    - DAEMON_VERSION=5.2.14
+    - RELEASE=2
   matrix:
   - OS_TYPE=fedora OS_VERSION=30
   - OS_TYPE=fedora OS_VERSION=29

--- a/Makefile
+++ b/Makefile
@@ -2,10 +2,10 @@
 # Versions
 #
 
-DAEMON_VERSION := 5.1.26
-DOWNLOAD_ID    := 1304    # This id number comes off the link on the displaylink website
+DAEMON_VERSION := 5.2.14
+DOWNLOAD_ID    := 1369    # This id number comes off the link on the displaylink website
 VERSION        := 1.6.2
-RELEASE        := 1
+RELEASE        := 2
 
 #
 # Dependencies

--- a/displaylink.spec
+++ b/displaylink.spec
@@ -130,6 +130,9 @@ fi
 /usr/bin/systemctl daemon-reload
 
 %changelog
+* Mon Aug 19 2019 Michael L. Young <elgueromexicano@gmail.com> 1.6.2-2
+- Update Displaylink driver to 5.2.14
+
 * Mon Jul 08 2019 Michael L. Young <elgueromexicano@gmail.com> 1.6.2-1
 - Update evdi to 1.6.2
 


### PR DESCRIPTION
These changes update the driver which is downloaded and packaged to be the
latest version provided by Displaylink which is currently 5.2.14.