### PR TITLE
Adding Fedora 31 as a target OS

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,7 @@ env:
     - DAEMON_VERSION=5.2.14
     - RELEASE=2
   matrix:
+  - OS_TYPE=fedora OS_VERSION=31
   - OS_TYPE=fedora OS_VERSION=30
   - OS_TYPE=fedora OS_VERSION=29
   - OS_TYPE=fedora OS_VERSION=28


### PR DESCRIPTION
This commit adds Fedora 31 as a target OS for building a RPM.