### PR TITLE
Update the evdi driver to version 1.6.3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,9 +2,9 @@ language: generic
 sudo: required
 env:
   global:
-    - VERSION=1.6.2
+    - VERSION=1.6.3
     - DAEMON_VERSION=5.2.14
-    - RELEASE=2
+    - RELEASE=1
   matrix:
   - OS_TYPE=fedora OS_VERSION=30
   - OS_TYPE=fedora OS_VERSION=29

--- a/Makefile
+++ b/Makefile
@@ -4,8 +4,8 @@
 
 DAEMON_VERSION := 5.2.14
 DOWNLOAD_ID    := 1369    # This id number comes off the link on the displaylink website
-VERSION        := 1.6.2
-RELEASE        := 2
+VERSION        := 1.6.3
+RELEASE        := 1
 
 #
 # Dependencies

--- a/displaylink.spec
+++ b/displaylink.spec
@@ -130,6 +130,9 @@ fi
 /usr/bin/systemctl daemon-reload
 
 %changelog
+* Tue Nov 05 2019 Michael L. Young <elgueromexicano@gmail.com> 1.6.3-1
+- Update the evdi driver to 1.6.3
+
 * Mon Aug 19 2019 Michael L. Young <elgueromexicano@gmail.com> 1.6.2-2
 - Update Displaylink driver to 5.2.14
 


### PR DESCRIPTION
This patch updates the RPM build to use evdi version 1.6.3 which was
just released.