### PR TITLE
Fixes related to evdi devel branch changes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,15 +2,15 @@ language: generic
 sudo: required
 env:
   global:
-    - VERSION=1.6.4
-    - DAEMON_VERSION=5.2.14
-    - RELEASE=3
+    - VERSION=1.7.0
+    - DAEMON_VERSION=5.3.1.34
+    - RELEASE=1
   matrix:
+  - OS_TYPE=fedora OS_VERSION=32
   - OS_TYPE=fedora OS_VERSION=31
   - OS_TYPE=fedora OS_VERSION=30
   - OS_TYPE=fedora OS_VERSION=29
   - OS_TYPE=fedora OS_VERSION=28
-  - OS_TYPE=fedora OS_VERSION=27
   - OS_TYPE=centos OS_VERSION=7
 services:
 - docker

--- a/Makefile
+++ b/Makefile
@@ -2,10 +2,10 @@
 # Versions
 #
 
-DAEMON_VERSION := 5.2.14
-DOWNLOAD_ID    := 1369    # This id number comes off the link on the displaylink website
-VERSION        := 1.6.4
-RELEASE        := 3
+DAEMON_VERSION := 5.3.1.34
+DOWNLOAD_ID    := 1576    # This id number comes off the link on the displaylink website
+VERSION        := 1.7.0
+RELEASE        := 1
 
 #
 # Dependencies


### PR DESCRIPTION
The changes are:
  * Updates related to the new evdi driver version 1.7.0.
  * Update to the released Displaylink driver 5.3.1.
  * The minimum kernel supported in evdi 1.7.0 is now 4.15. Adjusted the spec
    accordingly.
  * Remove Travis build for Fedora 27 since the kernel is no longer supported.
  * Add Fedora 32 build to Travis.
  * Fix support for DL-6xxx devices. The firmware image was not being copied from
    the DisplayLink driver package.
  * Adjust how we use dkms inside the rpm to follow recommended way outlined in the
    documentation.

Resolves #112, resolves #121, resolves #128