### PR TITLE
Updated evdi version to 1.7.1

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@
 
 DAEMON_VERSION := 5.3.1.34
 DOWNLOAD_ID    := 1576    # This id number comes off the link on the displaylink website
-VERSION        := 1.7.0
+VERSION        := 1.7.1
 RELEASE        := 2
 
 #

--- a/displaylink.spec
+++ b/displaylink.spec
@@ -78,8 +78,9 @@ cp -a $OLDPWD/evdi-%{version}/module/* . ; \
 popd
 
 # Library
-cp -a evdi-%{version}/library/libevdi.so.%{version} %{buildroot}%{_libexecdir}/%{name}/
-ln -s %{_libexecdir}/%{name}/libevdi.so.%{version} %{buildroot}%{_libexecdir}/%{name}/libevdi.so
+so_version=`sed 's/\.[^.]*$//'  <<< "%{version}"`.0
+cp -a evdi-%{version}/library/libevdi.so.${so_version} %{buildroot}%{_libexecdir}/%{name}/
+ln -s %{_libexecdir}/%{name}/libevdi.so.${so_version} %{buildroot}%{_libexecdir}/%{name}/libevdi.so
 
 # Binaries
 # Don't copy libusb-1.0.so.0.1.0 it's already shipped by libusbx


### PR DESCRIPTION
Updated to the last evdi release version.

Note that evdi 1.7.1 supplies libevdi.so.1.7.0. So the spec file was adapted to always have that file end on "0" on the last version identifier.