### PR TITLE
Add the ability to build with the bundled EVDI

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,7 +22,8 @@ EVDI_DEVEL_REPO     := https://github.com/DisplayLink/evdi.git
 EVDI_DEVEL_BASE_DIR := /var/tmp
 EVDI_DEVEL          := $(EVDI_DEVEL_BASE_DIR)/evdi-$(VERSION)
 
-BUILD_DEPS := $(DAEMON_PKG) $(EVDI_PKG) $(SPEC_FILE)
+BUILD_DEPS := $(DAEMON_PKG) $(SPEC_FILE)
+BUILD_DEPS_UNBUNDLED_EVDI := $(DAEMON_PKG) $(EVDI_PKG) $(SPEC_FILE)
 
 #
 # Targets
@@ -33,6 +34,12 @@ x86_64_RPM := x86_64/displaylink-$(VERSION)-$(RELEASE).x86_64.rpm
 SRPM       := displaylink-$(VERSION)-$(RELEASE).src.rpm
 
 TARGETS    := $(i386_RPM) $(x86_64_RPM) $(SRPM)
+
+i386_RPM_UNBUNDLED_EVDI   := i386/displaylink-$(VERSION)-$(RELEASE)-unbundled_evdi.i386.rpm
+x86_64_RPM_UNBUNDLED_EVDI := x86_64/displaylink-$(VERSION)-$(RELEASE)-unbundled_evdi.x86_64.rpm
+SRPM_UNBUNDLED_EVDI       := displaylink-$(VERSION)-$(RELEASE)-unbundled_evdi.src.rpm
+
+TARGETS_UNBUNDLED_EVDI := $(i386_RPM_UNBUNDLED_EVDI) $(x86_64_RPM_UNBUNDLED_EVDI) $(SRPM_UNBUNDLED_EVDI)
 
 #
 # Upstream checks
@@ -61,13 +68,19 @@ endef
 # PHONY targets
 #
 
-.PHONY: all rpm srpm devel rawhide clean clean-rawhide clean-mainline clean-all versions
+.PHONY: all unbundled rpm srpm rpm-unbundled srpm-unbundled devel rawhide clean clean-rawhide clean-mainline clean-all versions
 
 all: $(TARGETS)
 
+unbundled: $(TARGETS_UNBUNDLED_EVDI)
+
 rpm: $(i386_RPM) $(x86_64_RPM)
 
-srpm: $(SRPM)
+srpm: $(i386_RPM) $(x86_64_RPM)
+
+rpm-unbundled: $(i386_RPM_UNBUNDLED_EVDI) $(x86_64_RPM_UNBUNDLED_EVDI)
+
+srpm-unbundled: $(SRPM_UNBUNDLED_EVDI)
 
 devel: $(EVDI_DEVEL)
 	cd $(EVDI_DEVEL) && git pull
@@ -128,6 +141,8 @@ BUILD_DEFINES =                                                     \
     --define "_version $(VERSION)"                                  \
     --define "_tmppath `mktemp -d /var/tmp/displayportXXXXXX`"      \
 
+BUILD_DEFINES_UNBUNDLED_EVDI = --define "_unbundled 1"
+
 $(i386_RPM): $(BUILD_DEPS)
 	rpmbuild -bb $(BUILD_DEFINES) displaylink.spec --target=i386
 
@@ -136,3 +151,12 @@ $(x86_64_RPM): $(BUILD_DEPS)
 
 $(SRPM): $(BUILD_DEPS)
 	rpmbuild -bs $(BUILD_DEFINES) displaylink.spec
+
+$(i386_RPM_UNBUNDLED_EVDI): $(BUILD_DEPS_UNBUNDLED_EVDI)
+	rpmbuild -bb $(BUILD_DEFINES)$(BUILD_DEFINES_UNBUNDLED_EVDI) displaylink.spec --target=i386
+
+$(x86_64_RPM_UNBUNDLED_EVDI): $(BUILD_DEPS_UNBUNDLED_EVDI)
+	rpmbuild -bb $(BUILD_DEFINES)$(BUILD_DEFINES_UNBUNDLED_EVDI) displaylink.spec --target=x86_64
+
+$(SRPM_UNBUNDLED_EVDI): $(BUILD_DEPS_UNBUNDLED_EVDI)
+	rpmbuild -bs $(BUILD_DEFINES)$(BUILD_DEFINES_UNBUNDLED_EVDI) displaylink.spec

--- a/displaylink.spec
+++ b/displaylink.spec
@@ -70,9 +70,9 @@ docking stations, USB monitors, and USB adapters.
 %define logfile %{_localstatedir}/log/%{name}/%{name}.log
 
 %prep
-%setup -T -c
+%setup -q -T -c
 
-%setup -T -D -a 4
+%setup -q -T -D -a 4
 chmod +x displaylink-driver-%{_daemon_version}.run
 ./displaylink-driver-%{_daemon_version}.run --noexec --keep
 # This creates a displaylink-driver-$version subdirectory
@@ -84,7 +84,7 @@ mv displaylink-driver-%{_daemon_version}/evdi.tar.gz evdi-%{version}
 cd evdi-%{version}
 gzip -dc evdi.tar.gz | tar -xvvf -
 %else
-%setup -T -D -a 0
+%setup -q -T -D -a 0
 cd evdi-%{version}
 %endif
 


### PR DESCRIPTION
The latest DisplayLink driver, 5.4, has included a version of EVDI that
works with kernels 5.11 and 5.12. The version that is currently released
on the EVDI github repo does not work with these kernels, even though
they have the same release version.

We can now issue a `make` to use the bundled version. If we want to
build the latest release from github, we can issue a `make unbundled` to
build with what is released in the future on github.

This patch also fixes the globals that were recently added to only be
set if we have not defined these macros through the Makefile. Otherwise,
defining our variables using the Makefile will have no affect on the rpmbuild.