### PR TITLE
Update driver version to 5.4.1-55.174

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,8 +3,8 @@ os: linux
 env:
   global:
     - VERSION=1.9.1
-    - DAEMON_VERSION=5.4.0-55.153
-    - RELEASE=1
+    - DAEMON_VERSION=5.4.1-55.174
+    - RELEASE=2
   jobs:
   - OS_TYPE=fedora OS_VERSION=34
   - OS_TYPE=fedora OS_VERSION=33

--- a/Makefile
+++ b/Makefile
@@ -2,10 +2,10 @@
 # Versions
 #
 
-DAEMON_VERSION := 5.4.0-55.153
+DAEMON_VERSION := 5.4.1-55.174
 DOWNLOAD_ID    := 3751    # This id number comes off the link on the displaylink website
 VERSION        := 1.9.1
-RELEASE        := 1
+RELEASE        := 2
 
 #
 # Dependencies
@@ -122,7 +122,7 @@ $(EVDI_DEVEL):
 
 $(DAEMON_PKG):
 	wget -O $(DAEMON_PKG) \
-		"https://www.synaptics.com/sites/default/files/exe_files/2021-04/DisplayLink USB Graphics Software for Ubuntu5.4-EXE.zip"
+		"https://www.synaptics.com/sites/default/files/exe_files/2021-09/DisplayLink USB Graphics Software for Ubuntu5.4.1-EXE.zip"
 
 $(EVDI_PKG):
 	wget -O v$(VERSION).tar.gz \

--- a/displaylink.spec
+++ b/displaylink.spec
@@ -1,5 +1,5 @@
 %if 0%{!?_daemon_version}
-%global _daemon_version 5.4.0-55.153
+%global _daemon_version 5.4.1-55.174
 %endif
 
 %if 0%{!?_version}
@@ -7,7 +7,7 @@
 %endif
 
 %if 0%{!?_release}
-%global _release 1
+%global _release 2
 %endif
 
 %global debug_package %{nil}
@@ -214,6 +214,9 @@ chmod +x %{buildroot}%{_prefix}/lib/systemd/system-sleep/displaylink.sh
 %systemd_postun_with_restart displaylink.service
 
 %changelog
+* Tue Oct 19 2021 Rodrigo Araujo <araujo.rm@gmail.com> 1.9.1-2
+- Update driver version to 5.4.1-55.174
+
 * Mon Apr 19 2021 Pavel Valena <pvalena@redhat.com> 1.9.1-1
 - Enable spec to build cleanly using mock.
 


### PR DESCRIPTION
A new driver from DisplayLink website is available. This change adds it to the produced RPM.
Since evdi is still at 1.9.1 upstream, keep the package version but bump release number.
Tested with success with kernel 5.14.9-200.fc34.x86_64