### PR TITLE
Fix rawhide build, clarify using evdi github release package

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![Build Status](https://github.com/displaylink-rpm/displaylink-rpm/actions/workflows/buildcheck.yml/badge.svg)](https://github.com/displaylink-rpm/displaylink-rpm/actions/workflows/buildcheck.yml)
 
 This is the recipe for building the [DisplayLink driver][displaylink]
-in a RPM package for Fedora and CentOS. This driver supports the following
+in a RPM package for Fedora, CentOS 7 and Rocky Linux. This driver supports the following
 device families:
 
 - DL-6xxx
@@ -22,14 +22,25 @@ Packages get automatically built by GitHub Actions and get uploaded to
 
 ## Usage
 
-EDIT: now buildable cleanly via .spec file (in mock f.e.). Download files via `make srpm`.
-
 ---
 
-In order to compile the driver, just use make. The Makefile should
-download the file for you.
+> NOTE: Now buildable cleanly via .spec file (in mock f.e.). Download files
+> via `make srpm`.
 
-## Secure boot on Fedora
+In order to create the driver rpm package you can run the command `make` from
+within the checked out directory. The Makefile should download the files needed
+for you and create an RPM.
+
+A default `make` will use the evdi driver that is bundled with the Displaylink
+driver package. If you need to use a newer released version from the evdi Github
+repo and it is not currently present in the Displaylink driver package, you can
+do so by running:
+
+```bash
+make github-release
+```
+
+### Secure boot on Fedora
 
 To use displaylink-rpm and the evdi kernel module with secure boot enabled on
 Fedora you need to sign the module with an enrolled Machine Owner Key (MOK).
@@ -37,7 +48,7 @@ Fedora you need to sign the module with an enrolled Machine Owner Key (MOK).
 First create a self signed MOK:
 
 ``` bash
-$ openssl req -new -x509 -newkey rsa:2048 -keyout MOK.priv -outform DER -out \
+openssl req -new -x509 -newkey rsa:2048 -keyout MOK.priv -outform DER -out \
 MOK.der -nodes -days 36500 -subj "/CN=Displaylink/"
 ```
 
@@ -52,18 +63,22 @@ Then reboot your Fedora host and follow the instructions to enroll the key.
 Now you can sign the evdi module. This must be done for every kernel upgrade:
 
 ``` bash
-$ sudo modinfo -n evdi
-/lib/modules/5.10.19-200.fc33.x86_64/extra/evdi.ko.xz
-$ sudo unxz $(modinfo -n evdi)
-$ sudo /usr/src/kernels/$(uname -r)/scripts/sign-file sha256 ./MOK.priv \
-./MOK.der /lib/modules/$(uname -r)/extra/evdi.ko
-$ xz -f /lib/modules/$(uname -r)/extra/evdi.ko
+sudo modinfo -n evdi /lib/modules/5.10.19-200.fc33.x86_64/extra/evdi.ko.xz
+
+sudo unxz $(modinfo -n evdi)
+
+sudo /usr/src/kernels/$(uname -r)/scripts/sign-file sha256 ./MOK.priv \
+  ./MOK.der /lib/modules/$(uname -r)/extra/evdi.ko
+
+sudo xz -f /lib/modules/$(uname -r)/extra/evdi.ko
 ```
 
 Now any display, hdmi and/or dvi ports on your docking station should work,
 and the displaylink.service should run.
 
 ## Hardware-specific behavior
+
+---
 
 ### Dell D6000
 
@@ -89,6 +104,8 @@ device by commenting out a line in `/etc/pulse/default.pa`:
 
 ## Development Builds
 
+---
+
 Generally we want to track the current stable release of the evdi library.
 However, Fedora kernels are often much newer than those officially supported by
 that release and it is not uncommon for a new kernel to completely break the
@@ -96,20 +113,44 @@ build. This can leave you in a situation where you cannot upgrade your kernel
 without sacrificing your displaylink devices. This is not great if the new
 kernel has important security or performance fixes.
 
-Fortunately the evdi developers are usually pretty quick to make the
-appropriate fixes on their `devel` branch.  You can build a version of the rpm
-that uses the current edvi `devel` branch with:
+The evdi developers use the `devel` branch as their main branch for all changes.
+
+To pull the latest code from the `devel` branch and use it to build, do the
+following:
+
+``` bash
+make devel
+
+make github-release
+```
+
+Of course this `devel` branch will also include some experimental and less
+tested changes that may break things in other unexpected ways. So you should
+prefer the mainline build if it works, but if it breaks, you have the option of
+making a `devel` build.
+
+If you are using Fedora Rawhide, you can create a build which will automatically
+download from the `devel` branch and build by running:
 
 ``` bash
 make rawhide
 ```
 
-Of course this `devel` branch will also include some experimental and less
-tested changes that may break things in other unexpected ways. So you should prefer the
-mainline build if it works, but if it breaks, you have the option of making
-a `rawhide` build.
+> In the past, code in the `devel` branch would be tagged and that version is what
+> would be included in the Displaylink driver package.
+>
+> Recently, we are seeing newer changes appear in the Displaylink driver package
+> without the evdi library version being changed. This has created some confusion
+> and difficulty when it comes to maintenance updates.
+>
+> The evdi folks have [acknowledged this issue][roadmap_discussion] and are
+> working on making the process more transparent.
+
+[roadmap_discussion]: https://github.com/DisplayLink/evdi/issues/309#issuecomment-979831346
 
 ## Contributing
+
+---
 
 The easiest way to contribute with the package is to fork it and send
 a pull request in GitHub.

--- a/displaylink.spec
+++ b/displaylink.spec
@@ -22,18 +22,18 @@
 %global kernel_pkg_name kernel
 %endif
 
-%if 0%{?_unbundled}
-%global _unbundled_release .unbundled_evdi
+%if 0%{?_github}
+%global _github_release .github_evdi
 %endif
 
 Name:		displaylink
 Version:	%{_version}
-Release:	%{_release}%{?_unbundled_release}
+Release:	%{_release}%{?_github_release}
 Summary:	DisplayLink VGA/HDMI driver for DL-6xxx, DL-5xxx, DL-41xx and DL-3xxx adapters
 
 License:	GPLv2 and LGPLv2 and MIT and ASL 2.0 and Proprietary
 
-%if 0%{?_unbundled}
+%if 0%{?_github}
 Source0:	https://github.com/DisplayLink/evdi/archive/v%{version}.tar.gz
 %endif
 Source1:	displaylink.service
@@ -84,7 +84,7 @@ chmod +x displaylink-driver-%{_daemon_version}.run
 
 mkdir -p evdi-%{version}
 
-%if 0%{!?_unbundled:1}
+%if 0%{!?_github:1}
 mv displaylink-driver-%{_daemon_version}/evdi.tar.gz evdi-%{version}
 cd evdi-%{version}
 gzip -dc evdi.tar.gz | tar -xvvf -
@@ -219,6 +219,10 @@ chmod +x %{buildroot}%{_prefix}/lib/systemd/system-sleep/displaylink.sh
 %systemd_postun_with_restart displaylink.service
 
 %changelog
+* Mon Dec 27 2021 Michael L. Young <elgueromexicano@gmail.com> 1.9.1-2
+- Change 'unbundled' to 'github' as part of attempt to clarify
+  which evdi driver is being used in the RPM that is produced.
+
 * Tue Oct 19 2021 Rodrigo Araujo <araujo.rm@gmail.com> 1.9.1-2
 - Update driver version to 5.4.1-55.174
 


### PR DESCRIPTION
- Fix rawhide build to use package from Github and not the one
  that is being bundled with the Displaylink driver package

- Change wording of 'unbundled' to refer to Github package to
  clarify which tarball will be used in the RPM build.

- Cleanups and add more documentation to README

Fixes #173