### PR TITLE
None of the runtime artefacts depend on mutter; remove

### DIFF
--- a/displaylink.spec
+++ b/displaylink.spec
@@ -56,7 +56,6 @@ Requires:   %{kernel_pkg_name} >= 4.15, %{kernel_pkg_name}-devel >= 4.15
 Requires:   make
 Requires:   libusbx
 Requires:   xorg-x11-server-Xorg >= 1.16
-Requires:   mutter >= 3.32
 Conflicts:  xorg-x11-server-Xorg = 1.20.1
 
 Provides:   bundled(libevdi) = 1.10.1


### PR DESCRIPTION
Fixes displaylink-rpm/displaylink-rpm#208