### PR TITLE
Fedora 36 has been released; enable CI

### DIFF
--- a/.github/workflows/buildcheck.yml
+++ b/.github/workflows/buildcheck.yml
@@ -44,6 +44,9 @@ jobs:
           - os: fedora
             version: 35
             dockernamespace: fedora
+          - os: fedora
+            version: 36
+            dockernamespace: fedora
           - os: centos
             version: 7.9.2009
             dockernamespace: centos

--- a/.github/workflows/devbuild.yml
+++ b/.github/workflows/devbuild.yml
@@ -33,6 +33,9 @@ jobs:
           - os: fedora
             version: 35
             dockernamespace: fedora
+          - os: fedora
+            version: 36
+            dockernamespace: fedora
           - os: centos
             version: 7.9.2009
             dockernamespace: centos

--- a/.github/workflows/rawhidebuilds.yml
+++ b/.github/workflows/rawhidebuilds.yml
@@ -13,7 +13,7 @@ jobs:
       matrix:
         include:
           - os: fedora
-            version: 36
+            version: 37
             dockernamespace: fedora
           - os: fedora
             version: rawhide

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -34,6 +34,9 @@ jobs:
         - os: fedora
           version: 35
           dockernamespace: fedora
+        - os: fedora
+          version: 36
+          dockernamespace: fedora
         - os: centos
           version: 7.9.2009
           dockernamespace: centos


### PR DESCRIPTION
Fixes #205

Note that this almost certainly depends on #207 to cover the updated kernel in Fedora 36