### PR TITLE
Suppress wget progress reporting in (batch) build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -126,11 +126,11 @@ $(EVDI_DEVEL):
 	git clone --depth 1 -b $(EVDI_DEVEL_BRANCH) $(EVDI_DEVEL_REPO) $(EVDI_DEVEL)
 
 $(DAEMON_PKG):
-	wget -O $(DAEMON_PKG) \
+	wget --no-verbose -O $(DAEMON_PKG) \
 		"https://www.synaptics.com/sites/default/files/exe_files/2022-05/DisplayLink USB Graphics Software for Ubuntu5.6-EXE.zip"
 
 $(EVDI_PKG):
-	wget -O v$(VERSION).tar.gz \
+	wget --no-verbose -O v$(VERSION).tar.gz \
 		https://github.com/DisplayLink/evdi/archive/v$(VERSION).tar.gz
 
 BUILD_DEFINES =                                                     \


### PR DESCRIPTION
This removes about 500 lines of lines such as
      0K .......... .......... .......... .......... ..........  0%  590K 28s
from the build log.