### PR TITLE
Fix building for i386

### DIFF
--- a/.github/workflows/buildcheck.yml
+++ b/.github/workflows/buildcheck.yml
@@ -17,6 +17,7 @@ jobs:
         run: ci/testbuilding.sh
 
   buildTest:
+    needs: makeTest
     runs-on: ubuntu-latest
     container: 
       image: ${{ matrix.dockernamespace }}:${{ matrix.version }}
@@ -76,6 +77,7 @@ jobs:
         run: ci/${{ matrix.os }}.sh
 
   mockTest:
+    needs: makeTest
     runs-on: ubuntu-latest
     container: 
       image: rockylinux:8
@@ -87,7 +89,7 @@ jobs:
         run: |
           echo "Install Mock"
           dnf -y install epel-release
-          dnf -y install mock gcc gcc-c++ libdrm-devel rpm-build make wget
+          dnf -y install mock gcc gcc-c++ glibc-devel.x86_64 glibc-devel.i686 libdrm-devel rpm-build make wget
           echo "Get source files"
           make
           echo "Run mock build"

--- a/Makefile
+++ b/Makefile
@@ -149,6 +149,8 @@ BUILD_DEFINES =                                                     \
 BUILD_DEFINES_GITHUB_EVDI = --define "_github 1"
 
 $(i386_RPM): $(BUILD_DEPS)
+	CFLAGS='-m32 -march=i386' \
+	LDFLAGS='-m32 -march=i386' \
 	rpmbuild -bb $(BUILD_DEFINES) displaylink.spec --target=i386
 
 $(x86_64_RPM): $(BUILD_DEPS)

--- a/ci/centos-stream.sh
+++ b/ci/centos-stream.sh
@@ -1,9 +1,11 @@
 #!/bin/bash
 
+set -e
+
 if [ "$OSVERSION" = "stream9" ]; then
-    dnf install -y rpm-build make gcc wget git 'dnf-command(builddep)'
+    dnf install -y rpm-build make gcc glibc-devel.x86_64 glibc-devel.i686 wget git 'dnf-command(builddep)'
 else
-    dnf install -y gcc gcc-c++ libdrm-devel rpm-build make wget dnf-utils git --enablerepo=extras
+    dnf install -y gcc gcc-c++ glibc-devel.x86_64 glibc-devel.i686 libdrm-devel rpm-build make wget dnf-utils git --enablerepo=extras
 fi
 
 dnf builddep -y ./displaylink.spec

--- a/ci/centos.sh
+++ b/ci/centos.sh
@@ -1,6 +1,8 @@
 #!/bin/bash
 
-yum install -y gcc gcc-c++ libdrm-devel rpm-build make wget yum-utils git --enablerepo=extras
+set -e
+
+yum install -y gcc gcc-c++ libgcc.i686 glibc-devel.x86_64 glibc-devel.i686 libdrm-devel rpm-build make wget yum-utils git --enablerepo=extras
 
 yum-builddep -y ./displaylink.spec
 

--- a/ci/fedora.sh
+++ b/ci/fedora.sh
@@ -1,6 +1,8 @@
 #!/bin/bash
 
-dnf install -y rpm-build make gcc wget git 'dnf-command(builddep)'
+set -e
+
+dnf install -y rpm-build make gcc glibc-devel.x86_64 glibc-devel.i686 wget git 'dnf-command(builddep)'
 
 dnf builddep -y --spec ./displaylink.spec
 

--- a/ci/rocky.sh
+++ b/ci/rocky.sh
@@ -1,6 +1,8 @@
 #!/bin/bash
 
-dnf install -y gcc gcc-c++ libdrm-devel rpm-build make wget dnf-utils git --enablerepo=extras
+set -e
+
+dnf install -y gcc gcc-c++ glibc-devel.x86_64 glibc-devel.i686 libdrm-devel rpm-build make wget dnf-utils git 'dnf-command(builddep)' --enablerepo=extras
 
 dnf builddep -y ./displaylink.spec
 

--- a/ci/testbuilding.sh
+++ b/ci/testbuilding.sh
@@ -1,43 +1,39 @@
 #!/bin/bash
 
-dnf install -y gcc gcc-c++ libdrm-devel rpm-build make wget dnf-utils git --enablerepo=extras
+set -e
 
-dnf-builddep -y ./displaylink.spec
+dnf install -y gcc gcc-c++ glibc-devel.x86_64 glibc-devel.i686 libdrm-devel rpm-build make wget dnf-utils 'dnf-command(builddep)' git --enablerepo=extras
+
+dnf builddep -y ./displaylink.spec
 
 chown `id -u`:`id -g` -R .
 
 echo "Testing 'make srpm'"
 make srpm
 
-if [ $? -ne 0 ]; then exit 1; fi
 make clean-all
 
 echo "Testing 'make rpm'"
 make rpm
 
-if [ $? -ne 0 ]; then exit 1; fi
 make clean-all
 
 echo "Testing 'make srpm-github'"
 make srpm-github
 
-if [ $? -ne 0 ]; then exit 1; fi
 make clean-all
 
 echo "Testing 'make rpm-github'"
 make rpm-github
 
-if [ $? -ne 0 ]; then exit 1; fi
 make clean-all
 
 echo "Testing 'make all'"
 make all
 
-if [ $? -ne 0 ]; then exit 1; fi
 make clean-all
 
 echo "Testing 'make github-release'"
 make github-release
 
-if [ $? -ne 0 ]; then exit 1; fi
 make clean-all


### PR DESCRIPTION
Fix the build infrastructure to build i386.

At the same time, this sneaks in two slightly unrelated changes:
* make the buildTest and mockTest runs depend on (the success of) the makeTest job; this results in early failure in case something goes wrong
* add "set -e" everywhere to fail scripts immediately; this uncovered `dnf-builddep` being used, which does not exist

Generally it would seem as if the i386 builds might have been broken one way or the other; theoretically the i386 rpm now contains i386 artefacts, but I am not setup to properly test this.

Generally speaking, it might be worthwhile removing build support for simplicity, see https://github.com/displaylink-rpm/displaylink-rpm/issues/210