### PR TITLE
Patch Currently Released EVDI Driver

### DIFF
--- a/.github/workflows/buildcheck.yml
+++ b/.github/workflows/buildcheck.yml
@@ -78,7 +78,7 @@ jobs:
         run: |
           echo "OSVERSION=${{ matrix.version }}" >> $GITHUB_ENV
 
-      - if: ${{ always() }} && ${{ matrix.os }} == 'fedora' && ${{ matrix.version }} < 37
+      - if: ${{ always() }} && ${{ matrix.version }} < 37
         name: Run CI
         run: ci/${{ matrix.os }}.sh
 

--- a/.github/workflows/buildcheck.yml
+++ b/.github/workflows/buildcheck.yml
@@ -78,7 +78,7 @@ jobs:
         run: |
           echo "OSVERSION=${{ matrix.version }}" >> $GITHUB_ENV
 
-      - if: always() && matrix.version < 37
+      - if: always() && matrix.version < 37 || matrix.version == 'centos'
         name: Run CI
         run: ci/${{ matrix.os }}.sh
 

--- a/.github/workflows/buildcheck.yml
+++ b/.github/workflows/buildcheck.yml
@@ -69,7 +69,7 @@ jobs:
 
       - name: Specify Build Target
         run: |
-          echo "SPECIFICTARGET=" >> $GITHUB_ENV
+          echo "SPECIFICTARGET=devel" >> $GITHUB_ENV
           
       - name: Environment variable for OS version
         run: |

--- a/.github/workflows/buildcheck.yml
+++ b/.github/workflows/buildcheck.yml
@@ -83,7 +83,7 @@ jobs:
         run: ci/${{ matrix.os }}.sh
 
       - if: always() && matrix.os == 'fedora' && matrix.version > 36
-        name: Run CI
+        name: Run CI (Fedora 37+)
         run: ci/${{ matrix.os }}37plus.sh
 
   mockTest:

--- a/.github/workflows/buildcheck.yml
+++ b/.github/workflows/buildcheck.yml
@@ -78,7 +78,7 @@ jobs:
         run: |
           echo "OSVERSION=${{ matrix.version }}" >> $GITHUB_ENV
 
-      - if: always() && matrix.version < 37 || matrix.version == 'centos'
+      - if: always() && matrix.version < 37 || startsWith(matrix.os, 'centos')
         name: Run CI
         run: ci/${{ matrix.os }}.sh
 

--- a/.github/workflows/buildcheck.yml
+++ b/.github/workflows/buildcheck.yml
@@ -48,6 +48,9 @@ jobs:
           - os: fedora
             version: 36
             dockernamespace: fedora
+          - os: fedora
+            version: 37
+            dockernamespace: fedora
           - os: centos
             version: 7.9.2009
             dockernamespace: centos
@@ -75,9 +78,13 @@ jobs:
         run: |
           echo "OSVERSION=${{ matrix.version }}" >> $GITHUB_ENV
 
-      - if: ${{ always() }}
+      - if: ${{ always() }} && ${{ matrix.os }} == 'fedora' && ${{ matrix.version }} < 37
         name: Run CI
         run: ci/${{ matrix.os }}.sh
+
+      - if: ${{ always() }} && ${{ matrix.os }} == 'fedora' && ${{ matrix.version }} > 36
+        name: Run CI
+        run: ci/${{ matrix.os }}37plus.sh
 
   mockTest:
     needs: makeTest

--- a/.github/workflows/buildcheck.yml
+++ b/.github/workflows/buildcheck.yml
@@ -78,11 +78,11 @@ jobs:
         run: |
           echo "OSVERSION=${{ matrix.version }}" >> $GITHUB_ENV
 
-      - if: ${{ always() }} && ${{ matrix.version }} < 37
+      - if: always() && matrix.version < 37
         name: Run CI
         run: ci/${{ matrix.os }}.sh
 
-      - if: ${{ always() }} && ${{ matrix.os }} == 'fedora' && ${{ matrix.version }} > 36
+      - if: always() && matrix.os == 'fedora' && matrix.version > 36
         name: Run CI
         run: ci/${{ matrix.os }}37plus.sh
 

--- a/.github/workflows/devbuild.yml
+++ b/.github/workflows/devbuild.yml
@@ -36,6 +36,9 @@ jobs:
           - os: fedora
             version: 36
             dockernamespace: fedora
+          - os: fedora
+            version: 37
+            dockernamespace: fedora
           - os: centos
             version: 7.9.2009
             dockernamespace: centos
@@ -64,4 +67,9 @@ jobs:
           echo "OSVERSION=${{ matrix.version }}" >> $GITHUB_ENV
 
       - name: Run CI
+        if: ${{ matrix.os }} == 'fedora' && ${{ matrix.version }} < 37
         run: ci/${{ matrix.os }}.sh
+      
+      - name: Run CI (Fedora 37+)
+        if: ${{ matrix.os }} == 'fedora' && ${{ matrix.version }} > 36
+        run: ci/${{ matrix.os }}37plus.sh

--- a/.github/workflows/devbuild.yml
+++ b/.github/workflows/devbuild.yml
@@ -67,7 +67,7 @@ jobs:
           echo "OSVERSION=${{ matrix.version }}" >> $GITHUB_ENV
 
       - name: Run CI
-        if: ${{ matrix.os }} == 'fedora' && ${{ matrix.version }} < 37
+        if: ${{ matrix.version }} < 37
         run: ci/${{ matrix.os }}.sh
       
       - name: Run CI (Fedora 37+)

--- a/.github/workflows/devbuild.yml
+++ b/.github/workflows/devbuild.yml
@@ -67,7 +67,7 @@ jobs:
           echo "OSVERSION=${{ matrix.version }}" >> $GITHUB_ENV
 
       - name: Run CI
-        if: matrix.version < 37 || matrix.version == 'centos'
+        if: matrix.version < 37 || startsWith(matrix.os, 'centos')
         run: ci/${{ matrix.os }}.sh
       
       - name: Run CI (Fedora 37+)

--- a/.github/workflows/devbuild.yml
+++ b/.github/workflows/devbuild.yml
@@ -67,7 +67,7 @@ jobs:
           echo "OSVERSION=${{ matrix.version }}" >> $GITHUB_ENV
 
       - name: Run CI
-        if: matrix.version < 37
+        if: matrix.version < 37 || matrix.version == 'centos'
         run: ci/${{ matrix.os }}.sh
       
       - name: Run CI (Fedora 37+)

--- a/.github/workflows/devbuild.yml
+++ b/.github/workflows/devbuild.yml
@@ -67,9 +67,9 @@ jobs:
           echo "OSVERSION=${{ matrix.version }}" >> $GITHUB_ENV
 
       - name: Run CI
-        if: ${{ matrix.version }} < 37
+        if: matrix.version < 37
         run: ci/${{ matrix.os }}.sh
       
       - name: Run CI (Fedora 37+)
-        if: ${{ matrix.os }} == 'fedora' && ${{ matrix.version }} > 36
+        if: matrix.os == 'fedora' && matrix.version > 36
         run: ci/${{ matrix.os }}37plus.sh

--- a/.github/workflows/rawhidebuilds.yml
+++ b/.github/workflows/rawhidebuilds.yml
@@ -13,9 +13,6 @@ jobs:
       matrix:
         include:
           - os: fedora
-            version: 37
-            dockernamespace: fedora
-          - os: fedora
             version: rawhide
             dockernamespace: fedora
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -77,7 +77,12 @@ jobs:
           echo "OSVERSION=${{ matrix.version }}" >> $GITHUB_ENV
       
       - name: Run CI
+        if: ${{ matrix.os }} == 'fedora' && ${{ matrix.version }} < 37
         run: ci/${{ matrix.os }}.sh
+
+      - name: Run CI (Fedora 37+)
+        if: ${{ matrix.os }} == 'fedora' && ${{ matrix.version }} > 36
+        run: ci/${{ matrix.os }}37plus.sh
 
       - name: Rename files
         run: mv displaylink-${{ env.VERSION }}-${{ env.RELEASE }}${{ env.EVDISOURCE }}.src.rpm ${{ matrix.os }}-${{ matrix.version }}-displaylink-${{ env.VERSION }}-${{ env.RELEASE }}${{ env.EVDISOURCE }}.src.rpm

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -66,11 +66,11 @@ jobs:
 
       - name: Specify A Target For make
         run: |
-          echo "SPECIFICTARGET=" >> $GITHUB_ENV
+          echo "SPECIFICTARGET=devel" >> $GITHUB_ENV
 
       - name: Environment variable for setting name of RPM when using EVDI from Github
         run: |
-          echo "EVDISOURCE=" >> $GITHUB_ENV
+          echo "EVDISOURCE=devel" >> $GITHUB_ENV
 
       - name: Environment variable for OS version
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -88,7 +88,7 @@ jobs:
         run: ci/${{ matrix.os }}37plus.sh
 
       - name: Rename files
-      - run : ls -la
+        run : ls -la
       - run: mv displaylink-${{ env.VERSION }}-${{ env.RELEASE }}${{ env.EVDISOURCE }}.src.rpm ${{ matrix.os }}-${{ matrix.version }}-displaylink-${{ env.VERSION }}-${{ env.RELEASE }}${{ env.EVDISOURCE }}.src.rpm
       - run: mv x86_64/displaylink-${{ env.VERSION }}-${{ env.RELEASE }}${{ env.EVDISOURCE }}.x86_64.rpm ${{ matrix.os }}-${{ matrix.version }}-displaylink-${{ env.VERSION }}-${{ env.RELEASE }}${{ env.EVDISOURCE }}.x86_64.rpm
       - run: mv i386/displaylink-${{ env.VERSION }}-${{ env.RELEASE }}${{ env.EVDISOURCE }}.i386.rpm ${{ matrix.os }}-${{ matrix.version }}-displaylink-${{ env.VERSION }}-${{ env.RELEASE }}${{ env.EVDISOURCE }}.i386.rpm

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -77,7 +77,7 @@ jobs:
           echo "OSVERSION=${{ matrix.version }}" >> $GITHUB_ENV
       
       - name: Run CI
-        if: ${{ matrix.os }} == 'fedora' && ${{ matrix.version }} < 37
+        if: ${{ matrix.version }} < 37
         run: ci/${{ matrix.os }}.sh
 
       - name: Run CI (Fedora 37+)

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -77,11 +77,11 @@ jobs:
           echo "OSVERSION=${{ matrix.version }}" >> $GITHUB_ENV
       
       - name: Run CI
-        if: ${{ matrix.version }} < 37
+        if: matrix.version < 37
         run: ci/${{ matrix.os }}.sh
 
       - name: Run CI (Fedora 37+)
-        if: ${{ matrix.os }} == 'fedora' && ${{ matrix.version }} > 36
+        if: matrix.os == 'fedora' && matrix.version > 36
         run: ci/${{ matrix.os }}37plus.sh
 
       - name: Rename files

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -69,7 +69,7 @@ jobs:
 
       - name: Specify A Target For make
         run: |
-          echo "SPECIFICTARGET=devel" >> $GITHUB_ENV
+          echo "SPECIFICTARGET=" >> $GITHUB_ENV
 
       - name: Environment variable for setting name of RPM when using EVDI from Github
         run: |
@@ -78,6 +78,9 @@ jobs:
       - name: Environment variable for OS version
         run: |
           echo "OSVERSION=${{ matrix.version }}" >> $GITHUB_ENV
+
+      - name: Get Devel Branch Code
+        run: make devel
       
       - name: Run CI
         if: matrix.version < 37 || startsWith(matrix.os, 'centos')

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -69,7 +69,7 @@ jobs:
 
       - name: Specify A Target For make
         run: |
-          echo "SPECIFICTARGET=" >> $GITHUB_ENV
+          echo "SPECIFICTARGET=devel" >> $GITHUB_ENV
 
       - name: Environment variable for setting name of RPM when using EVDI from Github
         run: |
@@ -78,10 +78,7 @@ jobs:
       - name: Environment variable for OS version
         run: |
           echo "OSVERSION=${{ matrix.version }}" >> $GITHUB_ENV
-
-      - name: Get Devel Branch Code
-        run: make devel
-      
+     
       - name: Run CI
         if: matrix.version < 37 || startsWith(matrix.os, 'centos')
         run: ci/${{ matrix.os }}.sh
@@ -89,6 +86,9 @@ jobs:
       - name: Run CI (Fedora 37+)
         if: matrix.os == 'fedora' && matrix.version > 36
         run: ci/${{ matrix.os }}37plus.sh
+
+      - name: Run build
+        run: make
 
       - name: Rename files
         run : ls -la

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -73,7 +73,7 @@ jobs:
 
       - name: Environment variable for setting name of RPM when using EVDI from Github
         run: |
-          echo "EVDISOURCE=-evdi-devel-branch" >> $GITHUB_ENV
+          echo "EVDISOURCE=" >> $GITHUB_ENV
 
       - name: Environment variable for OS version
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -73,7 +73,7 @@ jobs:
 
       - name: Environment variable for setting name of RPM when using EVDI from Github
         run: |
-          echo "EVDISOURCE=devel" >> $GITHUB_ENV
+          echo "EVDISOURCE=-evdi-devel-branch" >> $GITHUB_ENV
 
       - name: Environment variable for OS version
         run: |
@@ -88,7 +88,8 @@ jobs:
         run: ci/${{ matrix.os }}37plus.sh
 
       - name: Rename files
-        run: mv displaylink-${{ env.VERSION }}-${{ env.RELEASE }}${{ env.EVDISOURCE }}.src.rpm ${{ matrix.os }}-${{ matrix.version }}-displaylink-${{ env.VERSION }}-${{ env.RELEASE }}${{ env.EVDISOURCE }}.src.rpm
+      - run : ls -la
+      - run: mv displaylink-${{ env.VERSION }}-${{ env.RELEASE }}${{ env.EVDISOURCE }}.src.rpm ${{ matrix.os }}-${{ matrix.version }}-displaylink-${{ env.VERSION }}-${{ env.RELEASE }}${{ env.EVDISOURCE }}.src.rpm
       - run: mv x86_64/displaylink-${{ env.VERSION }}-${{ env.RELEASE }}${{ env.EVDISOURCE }}.x86_64.rpm ${{ matrix.os }}-${{ matrix.version }}-displaylink-${{ env.VERSION }}-${{ env.RELEASE }}${{ env.EVDISOURCE }}.x86_64.rpm
       - run: mv i386/displaylink-${{ env.VERSION }}-${{ env.RELEASE }}${{ env.EVDISOURCE }}.i386.rpm ${{ matrix.os }}-${{ matrix.version }}-displaylink-${{ env.VERSION }}-${{ env.RELEASE }}${{ env.EVDISOURCE }}.i386.rpm
       - run: chown `id -u`:`id -g` -R .

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -77,7 +77,7 @@ jobs:
           echo "OSVERSION=${{ matrix.version }}" >> $GITHUB_ENV
       
       - name: Run CI
-        if: matrix.version < 37
+        if: matrix.version < 37 || matrix.version == 'centos'
         run: ci/${{ matrix.os }}.sh
 
       - name: Run CI (Fedora 37+)

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -37,6 +37,9 @@ jobs:
         - os: fedora
           version: 36
           dockernamespace: fedora
+        - os: fedora
+          version: 37
+          dockernamespace: fedora
         - os: centos
           version: 7.9.2009
           dockernamespace: centos

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -77,7 +77,7 @@ jobs:
           echo "OSVERSION=${{ matrix.version }}" >> $GITHUB_ENV
       
       - name: Run CI
-        if: matrix.version < 37 || matrix.version == 'centos'
+        if: matrix.version < 37 || startsWith(matrix.os, 'centos')
         run: ci/${{ matrix.os }}.sh
 
       - name: Run CI (Fedora 37+)

--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@
 DAEMON_VERSION := 5.6.1-59.184
 DOWNLOAD_ID    := 4781    # This id number comes off the link on the displaylink website
 VERSION        := 1.12.0
-RELEASE        := 1
+RELEASE        := 2
 
 #
 # Dependencies

--- a/ci/testbuilding.sh
+++ b/ci/testbuilding.sh
@@ -18,22 +18,22 @@ make rpm
 
 make clean-all
 
-echo "Testing 'make srpm-github'"
-make srpm-github
+# echo "Testing 'make srpm-github'"
+# make srpm-github
 
-make clean-all
+# make clean-all
 
-echo "Testing 'make rpm-github'"
-make rpm-github
+# echo "Testing 'make rpm-github'"
+# make rpm-github
 
-make clean-all
+# make clean-all
 
-echo "Testing 'make all'"
-make all
+# echo "Testing 'make all'"
+# make all
 
-make clean-all
+# make clean-all
 
-echo "Testing 'make github-release'"
-make github-release
+# echo "Testing 'make github-release'"
+# make github-release
 
-make clean-all
+# make clean-all

--- a/displaylink.spec
+++ b/displaylink.spec
@@ -1,6 +1,6 @@
 %{!?_daemon_version:%global _daemon_version 5.6.1-59.184}
 %{!?_version:%global _version 1.12.0}
-%{!?_release:%global _release 1}
+%{!?_release:%global _release 2}
 
 # Disable RPATH since DisplayLinkManager contains this.
 # Fedora 35 enforces this check and will stop rpmbuild from
@@ -36,6 +36,9 @@ Source6:  95-displaylink.preset
 Source7:  %{name}.logrotate
 Source8:  displaylink-udev-extractor.sh
 Source9:  evdi.conf
+
+Patch0:   evdi-el-fixes.diff
+Patch1:   evdi-bundled-devel-patches.diff
 
 BuildRequires:  gcc-c++
 BuildRequires:  libdrm-devel
@@ -82,10 +85,12 @@ mkdir -p evdi-%{version}
 mv displaylink-driver-%{_daemon_version}/evdi.tar.gz evdi-%{version}
 cd evdi-%{version}
 gzip -dc evdi.tar.gz | tar -xvvf -
+%patch1 -p1
 
 %else
 %setup -q -T -D -a 0
 cd evdi-%{version}
+%patch0 -p1
 %endif
 
 sed -i 's/\r//' README.md
@@ -252,6 +257,15 @@ done
 %systemd_postun_with_restart displaylink-driver.service
 
 %changelog
+* Mon Nov 28 2022 Michael L. Young <elgueromexicano@gmail.com> 1.12.0-2
+- Add patch for evdi to compile with newer EL 8.7 and EL 9.1 releases
+  with the github release
+- Add patch for evdi to compile with newer kernels, EL 8.7 and EL 9.1
+  releases using the bundled evdi driver
+
+* Fri Oct 14 2022 Michael L. Young <elgueromexicano@gmail.com> 1.12.0-2
+- Remove EL8 and EL9 evdi patches that were merged upstream
+
 * Sat Aug 13 2022 Michael L. Young <elgueromexicano@gmail> 1.12.0-1
 - Update to use the new DisplayLink 5.6.1 package
 - Update to use evdi module 1.12.0

--- a/evdi-bundled-devel-patches.diff
+++ b/evdi-bundled-devel-patches.diff
@@ -1,0 +1,397 @@
+diff -ru evdi-1.12.0-c/module/evdi_drm_drv.c evdi-1.12.0-d/module/evdi_drm_drv.c
+--- evdi-1.12.0-c/module/evdi_drm_drv.c	2022-07-13 09:58:06.000000000 -0400
++++ evdi-1.12.0-d/module/evdi_drm_drv.c	2022-11-28 22:11:51.459566000 -0500
+@@ -12,7 +12,7 @@
+  */
+ 
+ #include <linux/version.h>
+-#if KERNEL_VERSION(5, 16, 0) <= LINUX_VERSION_CODE
++#if KERNEL_VERSION(5, 16, 0) <= LINUX_VERSION_CODE || defined(EL9)
+ #include <drm/drm_ioctl.h>
+ #include <drm/drm_file.h>
+ #include <drm/drm_drv.h>
+@@ -24,7 +24,7 @@
+ #if KERNEL_VERSION(5, 1, 0) <= LINUX_VERSION_CODE || defined(EL8)
+ #include <drm/drm_probe_helper.h>
+ #endif
+-#if KERNEL_VERSION(5, 8, 0) <= LINUX_VERSION_CODE
++#if KERNEL_VERSION(5, 8, 0) <= LINUX_VERSION_CODE || defined(EL8)
+ #include <drm/drm_managed.h>
+ #endif
+ #include <drm/drm_atomic_helper.h>
+@@ -146,7 +146,7 @@
+ 	.patchlevel = DRIVER_PATCH,
+ };
+ 
+-#if KERNEL_VERSION(5, 8, 0) <= LINUX_VERSION_CODE
++#if KERNEL_VERSION(5, 8, 0) <= LINUX_VERSION_CODE || defined(EL8)
+ static void evdi_drm_device_release_cb(__always_unused struct drm_device *dev,
+ 				       __always_unused void *ptr)
+ {
+@@ -192,7 +192,7 @@
+ 
+ 	drm_kms_helper_poll_init(dev);
+ 
+-#if KERNEL_VERSION(5, 8, 0) <= LINUX_VERSION_CODE
++#if KERNEL_VERSION(5, 8, 0) <= LINUX_VERSION_CODE || defined(EL8)
+ 	ret = drmm_add_action_or_reset(dev, evdi_drm_device_release_cb, NULL);
+ 	if (ret)
+ 		goto err_fb;
+diff -ru evdi-1.12.0-c/module/evdi_drm_drv.h evdi-1.12.0-d/module/evdi_drm_drv.h
+--- evdi-1.12.0-c/module/evdi_drm_drv.h	2022-07-13 09:58:06.000000000 -0400
++++ evdi-1.12.0-d/module/evdi_drm_drv.h	2022-11-28 22:12:00.274730700 -0500
+@@ -25,8 +25,8 @@
+ #else
+ #include <drm/drmP.h>
+ #endif
+-#if KERNEL_VERSION(5, 15, 0) <= LINUX_VERSION_CODE
+-#include <drm/drm_legacy.h>
++#if KERNEL_VERSION(5, 15, 0) <= LINUX_VERSION_CODE || defined(EL8) || defined(EL9)
++#include <drm/drm_framebuffer.h>
+ #else
+ #include <drm/drm_irq.h>
+ #endif
+diff -ru evdi-1.12.0-c/module/evdi_gem.c evdi-1.12.0-d/module/evdi_gem.c
+--- evdi-1.12.0-c/module/evdi_gem.c	2022-07-13 09:58:06.000000000 -0400
++++ evdi-1.12.0-d/module/evdi_gem.c	2022-11-28 22:12:00.310068500 -0500
+@@ -10,11 +10,11 @@
+ 
+ #include <linux/sched.h>
+ #include <linux/version.h>
+-#if KERNEL_VERSION(5, 18, 0) <= LINUX_VERSION_CODE
++#if KERNEL_VERSION(5, 18, 0) <= LINUX_VERSION_CODE || defined(EL8) || defined(EL9)
+ #elif KERNEL_VERSION(5, 11, 0) <= LINUX_VERSION_CODE
+ #include <linux/dma-buf-map.h>
+ #endif
+-#if KERNEL_VERSION(5, 16, 0) <= LINUX_VERSION_CODE
++#if KERNEL_VERSION(5, 16, 0) <= LINUX_VERSION_CODE || defined(EL9)
+ #include <drm/drm_prime.h>
+ #include <drm/drm_file.h>
+ #elif KERNEL_VERSION(5, 5, 0) <= LINUX_VERSION_CODE || defined(EL8)
+@@ -27,7 +27,7 @@
+ #include <linux/dma-buf.h>
+ #include <drm/drm_cache.h>
+ 
+-#if KERNEL_VERSION(5, 16, 0) <= LINUX_VERSION_CODE
++#if KERNEL_VERSION(5, 16, 0) <= LINUX_VERSION_CODE || defined(EL9)
+ MODULE_IMPORT_NS(DMA_BUF);
+ #endif
+ 
+@@ -62,10 +62,10 @@
+ 
+ static bool evdi_drm_gem_object_use_import_attach(struct drm_gem_object *obj)
+ {
+-	if (!obj || !obj->import_attach)
++	if (!obj || !obj->import_attach || !obj->import_attach->dmabuf->owner)
+ 		return false;
+ 
+-	return obj->import_attach && strcmp(obj->import_attach->dmabuf->owner->name, "amdgpu") != 0;
++	return strcmp(obj->import_attach->dmabuf->owner->name, "amdgpu") != 0;
+ }
+ 
+ uint32_t evdi_gem_object_handle_lookup(struct drm_file *filp,
+@@ -291,7 +291,7 @@
+ 	int ret;
+ 
+ 	if (evdi_drm_gem_object_use_import_attach(&obj->base)) {
+-#if KERNEL_VERSION(5, 18, 0) <= LINUX_VERSION_CODE
++#if KERNEL_VERSION(5, 18, 0) <= LINUX_VERSION_CODE || defined(EL8) || defined(EL9)
+ 		struct iosys_map map = IOSYS_MAP_INIT_VADDR(NULL);
+ #elif KERNEL_VERSION(5, 11, 0) <= LINUX_VERSION_CODE || defined(EL8)
+ 		struct dma_buf_map map = DMA_BUF_MAP_INIT_VADDR(NULL);
+@@ -324,7 +324,7 @@
+ void evdi_gem_vunmap(struct evdi_gem_object *obj)
+ {
+ 	if (evdi_drm_gem_object_use_import_attach(&obj->base)) {
+-#if KERNEL_VERSION(5, 18, 0) <= LINUX_VERSION_CODE
++#if KERNEL_VERSION(5, 18, 0) <= LINUX_VERSION_CODE || defined(EL8) || defined(EL9)
+ 		struct iosys_map map = IOSYS_MAP_INIT_VADDR(NULL);
+ 
+ 		if (obj->vmap_is_iomem)
+diff -ru evdi-1.12.0-c/module/evdi_ioc32.c evdi-1.12.0-d/module/evdi_ioc32.c
+--- evdi-1.12.0-c/module/evdi_ioc32.c	2022-07-13 09:58:06.000000000 -0400
++++ evdi-1.12.0-d/module/evdi_ioc32.c	2022-11-28 22:12:00.321706800 -0500
+@@ -22,7 +22,7 @@
+ #include <linux/compat.h>
+ 
+ #include <linux/version.h>
+-#if KERNEL_VERSION(5, 16, 0) <= LINUX_VERSION_CODE
++#if KERNEL_VERSION(5, 16, 0) <= LINUX_VERSION_CODE || defined(EL9)
+ #include <drm/drm_ioctl.h>
+ #elif KERNEL_VERSION(5, 5, 0) <= LINUX_VERSION_CODE || defined(EL8)
+ #else
+@@ -62,10 +62,10 @@
+ 	if (copy_from_user(&req32, (void __user *)arg, sizeof(req32)))
+ 		return -EFAULT;
+ 
+-#if KERNEL_VERSION(5, 0, 0) <= LINUX_VERSION_CODE && KERNEL_VERSION(5, 14, 0) >= LINUX_VERSION_CODE || defined(EL8)
+-	request = compat_alloc_user_space(sizeof(*request));
+-#else
++#if KERNEL_VERSION(5, 15, 0) <= LINUX_VERSION_CODE || defined(EL8) || defined(EL9)
+ 	request = kmalloc(sizeof(*request), GFP_USER);
++#elif KERNEL_VERSION(5, 0, 0) <= LINUX_VERSION_CODE
++	request = compat_alloc_user_space(sizeof(*request));
+ #endif
+ #if KERNEL_VERSION(5, 0, 0) <= LINUX_VERSION_CODE || defined(EL8)
+ 	if (!access_ok(request, sizeof(*request))
+@@ -95,10 +95,10 @@
+ 	if (copy_from_user(&req32, (void __user *)arg, sizeof(req32)))
+ 		return -EFAULT;
+ 
+-#if KERNEL_VERSION(5, 0, 0) <= LINUX_VERSION_CODE && KERNEL_VERSION(5, 14, 0) >= LINUX_VERSION_CODE || defined(EL8)
+-	request = compat_alloc_user_space(sizeof(*request));
+-#else
++#if KERNEL_VERSION(5, 15, 0) <= LINUX_VERSION_CODE || defined(EL8) || defined(EL9)
+ 	request = kmalloc(sizeof(*request), GFP_USER);
++#elif KERNEL_VERSION(5, 0, 0) <= LINUX_VERSION_CODE
++	request = compat_alloc_user_space(sizeof(*request));
+ #endif
+ #if KERNEL_VERSION(5, 0, 0) <= LINUX_VERSION_CODE || defined(EL8)
+ 	if (!access_ok(request, sizeof(*request))
+diff -ru evdi-1.12.0-c/module/evdi_modeset.c evdi-1.12.0-d/module/evdi_modeset.c
+--- evdi-1.12.0-c/module/evdi_modeset.c	2022-07-13 09:58:06.000000000 -0400
++++ evdi-1.12.0-d/module/evdi_modeset.c	2022-11-28 22:11:51.553776900 -0500
+@@ -12,7 +12,7 @@
+  */
+ 
+ #include <linux/version.h>
+-#if KERNEL_VERSION(5, 16, 0) <= LINUX_VERSION_CODE
++#if KERNEL_VERSION(5, 16, 0) <= LINUX_VERSION_CODE || defined(EL9)
+ #include <drm/drm_vblank.h>
+ #include <drm/drm_damage_helper.h>
+ #elif KERNEL_VERSION(5, 0, 0) <= LINUX_VERSION_CODE || defined(EL8)
+@@ -29,7 +29,7 @@
+ #include "evdi_drm_drv.h"
+ #include "evdi_cursor.h"
+ #include "evdi_params.h"
+-#if KERNEL_VERSION(5, 13, 0) <= LINUX_VERSION_CODE
++#if KERNEL_VERSION(5, 13, 0) <= LINUX_VERSION_CODE || defined(EL8)
+ #include <drm/drm_gem_atomic_helper.h>
+ #else
+ #include <drm/drm_gem_framebuffer_helper.h>
+@@ -220,14 +220,14 @@
+ };
+ 
+ static void evdi_plane_atomic_update(struct drm_plane *plane,
+-#if KERNEL_VERSION(5, 13, 0) <= LINUX_VERSION_CODE
++#if KERNEL_VERSION(5, 13, 0) <= LINUX_VERSION_CODE || defined(EL8)
+ 				     struct drm_atomic_state *atom_state
+ #else
+ 				     struct drm_plane_state *old_state
+ #endif
+ 		)
+ {
+-#if KERNEL_VERSION(5, 13, 0) <= LINUX_VERSION_CODE
++#if KERNEL_VERSION(5, 13, 0) <= LINUX_VERSION_CODE || defined(EL8)
+ 	struct drm_plane_state *old_state = drm_atomic_get_old_plane_state(atom_state, plane);
+ #else
+ #endif
+@@ -318,14 +318,14 @@
+ }
+ 
+ static void evdi_cursor_atomic_update(struct drm_plane *plane,
+-#if KERNEL_VERSION(5, 13, 0) <= LINUX_VERSION_CODE
++#if KERNEL_VERSION(5, 13, 0) <= LINUX_VERSION_CODE || defined(EL8)
+ 				     struct drm_atomic_state *atom_state
+ #else
+ 				     struct drm_plane_state *old_state
+ #endif
+ 		)
+ {
+-#if KERNEL_VERSION(5, 13, 0) <= LINUX_VERSION_CODE
++#if KERNEL_VERSION(5, 13, 0) <= LINUX_VERSION_CODE || defined(EL8)
+ 	struct drm_plane_state *old_state = drm_atomic_get_old_plane_state(atom_state, plane);
+ #else
+ #endif
+@@ -395,7 +395,7 @@
+ 
+ static const struct drm_plane_helper_funcs evdi_plane_helper_funcs = {
+ 	.atomic_update = evdi_plane_atomic_update,
+-#if KERNEL_VERSION(5, 13, 0) <= LINUX_VERSION_CODE
++#if KERNEL_VERSION(5, 13, 0) <= LINUX_VERSION_CODE || defined(EL8)
+ 	.prepare_fb = drm_gem_plane_helper_prepare_fb
+ #else
+ 	.prepare_fb = drm_gem_fb_prepare_fb
+@@ -404,7 +404,7 @@
+ 
+ static const struct drm_plane_helper_funcs evdi_cursor_helper_funcs = {
+ 	.atomic_update = evdi_cursor_atomic_update,
+-#if KERNEL_VERSION(5, 13, 0) <= LINUX_VERSION_CODE
++#if KERNEL_VERSION(5, 13, 0) <= LINUX_VERSION_CODE || defined(EL8)
+ 	.prepare_fb = drm_gem_plane_helper_prepare_fb
+ #else
+ 	.prepare_fb = drm_gem_fb_prepare_fb
+@@ -538,7 +538,7 @@
+ 
+ void evdi_modeset_cleanup(__maybe_unused struct drm_device *dev)
+ {
+-#if KERNEL_VERSION(5, 8, 0) <= LINUX_VERSION_CODE
++#if KERNEL_VERSION(5, 8, 0) <= LINUX_VERSION_CODE || defined(EL8)
+ #else
+ 	drm_mode_config_cleanup(dev);
+ #endif
+diff -ru evdi-1.12.0-c/module/evdi_painter.c evdi-1.12.0-d/module/evdi_painter.c
+--- evdi-1.12.0-c/module/evdi_painter.c	2022-07-13 09:58:06.000000000 -0400
++++ evdi-1.12.0-d/module/evdi_painter.c	2022-11-28 22:11:51.608358500 -0500
+@@ -10,7 +10,7 @@
+ #include "linux/thread_info.h"
+ #include "linux/mm.h"
+ #include <linux/version.h>
+-#if KERNEL_VERSION(5, 16, 0) <= LINUX_VERSION_CODE
++#if KERNEL_VERSION(5, 16, 0) <= LINUX_VERSION_CODE || defined(EL9)
+ #include <drm/drm_file.h>
+ #include <drm/drm_vblank.h>
+ #include <drm/drm_ioctl.h>
+@@ -31,7 +31,7 @@
+ 
+ #include <linux/dma-buf.h>
+ 
+-#if KERNEL_VERSION(5, 16, 0) <= LINUX_VERSION_CODE
++#if KERNEL_VERSION(5, 16, 0) <= LINUX_VERSION_CODE || defined(EL9)
+ MODULE_IMPORT_NS(DMA_BUF);
+ #endif
+ 
+@@ -727,7 +727,7 @@
+ static void evdi_log_pixel_format(uint32_t pixel_format,
+ 		char *buf, size_t size)
+ {
+-#if KERNEL_VERSION(5, 14, 0) <= LINUX_VERSION_CODE
++#if KERNEL_VERSION(5, 14, 0) <= LINUX_VERSION_CODE || defined(EL8)
+ 	snprintf(buf, size, "pixel format %p4cc", &pixel_format);
+ #else
+ 	struct drm_format_name_buf format_name;
+@@ -885,7 +885,7 @@
+ 
+ 	painter_lock(painter);
+ 
+-        evdi->pixel_area_limit = pixel_area_limit;
++	evdi->pixel_area_limit = pixel_area_limit;
+ 	evdi->pixel_per_second_limit = pixel_per_second_limit;
+ 	painter->drm_filp = file;
+ 	kfree(painter->edid);
+diff -ru evdi-1.12.0-c/module/evdi_platform_drv.c evdi-1.12.0-d/module/evdi_platform_drv.c
+--- evdi-1.12.0-c/module/evdi_platform_drv.c	2022-07-13 09:58:06.000000000 -0400
++++ evdi-1.12.0-d/module/evdi_platform_drv.c	2022-11-28 22:11:51.620696400 -0500
+@@ -12,7 +12,9 @@
+ #include <linux/module.h>
+ #include <linux/platform_device.h>
+ #include <linux/dma-mapping.h>
++#ifdef CONFIG_USB_SUPPORT
+ #include <linux/usb.h>
++#endif
+ 
+ #include "evdi_params.h"
+ #include "evdi_debug.h"
+@@ -30,7 +32,9 @@
+ 	struct device *root_dev;
+ 	unsigned int dev_count;
+ 	struct platform_device *devices[EVDI_DEVICE_COUNT_MAX];
++#ifdef CONFIG_USB_SUPPORT
+ 	struct notifier_block usb_notifier;
++#endif
+ 	struct mutex lock;
+ } g_ctx;
+ 
+@@ -40,6 +44,7 @@
+ #define evdi_platform_drv_context_unlock(ctx) \
+ 		mutex_unlock(&ctx->lock)
+ 
++#ifdef CONFIG_USB_SUPPORT
+ static int evdi_platform_drv_usb(__always_unused struct notifier_block *nb,
+ 		unsigned long action,
+ 		void *data)
+@@ -69,6 +74,7 @@
+ 	}
+ 	return 0;
+ }
++#endif
+ 
+ static int evdi_platform_drv_get_free_idx(struct evdi_platform_drv_context *ctx)
+ {
+@@ -213,11 +219,15 @@
+ 
+ 	memset(&g_ctx, 0, sizeof(g_ctx));
+ 	g_ctx.root_dev = root_device_register(DRIVER_NAME);
++#ifdef CONFIG_USB_SUPPORT
+ 	g_ctx.usb_notifier.notifier_call = evdi_platform_drv_usb;
++#endif
+ 	mutex_init(&g_ctx.lock);
+ 	dev_set_drvdata(g_ctx.root_dev, &g_ctx);
+ 
++#ifdef CONFIG_USB_SUPPORT
+ 	usb_register_notify(&g_ctx.usb_notifier);
++#endif
+ 	evdi_sysfs_init(g_ctx.root_dev);
+ 	ret = platform_driver_register(&evdi_platform_driver);
+ 	if (ret)
+@@ -238,7 +248,9 @@
+ 
+ 	if (!PTR_ERR_OR_ZERO(g_ctx.root_dev)) {
+ 		evdi_sysfs_exit(g_ctx.root_dev);
++#ifdef CONFIG_USB_SUPPORT
+ 		usb_unregister_notify(&g_ctx.usb_notifier);
++#endif
+ 		dev_set_drvdata(g_ctx.root_dev, NULL);
+ 		root_device_unregister(g_ctx.root_dev);
+ 	}
+diff -ru evdi-1.12.0-c/module/evdi_sysfs.c evdi-1.12.0-d/module/evdi_sysfs.c
+--- evdi-1.12.0-c/module/evdi_sysfs.c	2022-07-13 09:58:06.000000000 -0400
++++ evdi-1.12.0-d/module/evdi_sysfs.c	2022-11-28 22:11:51.656906100 -0500
+@@ -51,6 +51,7 @@
+ 	struct usb_device *usb;
+ };
+ 
++#ifdef CONFIG_USB_SUPPORT
+ static int evdi_platform_device_attach(struct device *device,
+ 		struct evdi_usb_addr *parent_addr);
+ 
+@@ -166,6 +167,16 @@
+ 	return evdi_platform_device_add(device, parent);
+ }
+ 
++#else /* !CONFIG_USB_SUPPORT */
++
++static ssize_t add_device_with_usb_path(struct device *dev,
++			 const char *buf, size_t count)
++{
++	return -EINVAL;
++}
++
++#endif /* CONFIG_USB_SUPPORT */
++
+ static ssize_t add_store(struct device *dev,
+ 			 __always_unused struct device_attribute *attr,
+ 			 const char *buf, size_t count)
+diff -ru evdi-1.12.0-c/module/Makefile evdi-1.12.0-d/module/Makefile
+--- evdi-1.12.0-c/module/Makefile	2022-07-13 09:58:06.000000000 -0400
++++ evdi-1.12.0-d/module/Makefile	2022-11-28 22:11:51.667147000 -0500
+@@ -11,6 +11,11 @@
+ EL8FLAG := -DEL8
+ endif
+ 
++EL9 := $(shell cat /etc/redhat-release 2>/dev/null | grep -c " 9." )
++ifneq (,$(findstring 1, $(EL9)))
++EL9FLAG := -DEL9
++endif
++
+ Raspbian := $(shell grep -Eic 'raspb(erry|ian)' /proc/cpuinfo /etc/os-release 2>/dev/null )
+ ifeq (,$(findstring 0, $(Raspbian)))
+ RPIFLAG := -DRPI
+@@ -22,7 +27,7 @@
+ 
+ KERN_DIR := /lib/modules/$(KERNELRELEASE)/build
+ 
+-ccflags-y := -Iinclude/drm $(EL8FLAG) $(RPIFLAG)
++ccflags-y := -Iinclude/drm $(EL8FLAG) $(EL9FLAG) $(RPIFLAG)
+ evdi-y := evdi_platform_drv.o evdi_platform_dev.o evdi_sysfs.o evdi_modeset.o evdi_connector.o evdi_encoder.o evdi_drm_drv.o evdi_fb.o evdi_gem.o evdi_painter.o evdi_params.o evdi_cursor.o evdi_debug.o evdi_i2c.o
+ evdi-$(CONFIG_COMPAT) += evdi_ioc32.o
+ obj-m := evdi.o
+@@ -45,7 +50,7 @@
+ # inside kbuild
+ # Note: this can be removed once it is in kernel tree and Kconfig is properly used
+ CONFIG_DRM_EVDI := m
+-ccflags-y := -isystem include/drm $(CFLAGS) $(EL8FLAG) $(RPIFLAG)
++ccflags-y := -isystem include/drm $(CFLAGS) $(EL8FLAG) $(EL9FLAG) $(RPIFLAG)
+ evdi-y := evdi_platform_drv.o evdi_platform_dev.o evdi_sysfs.o evdi_modeset.o evdi_connector.o evdi_encoder.o evdi_drm_drv.o evdi_fb.o evdi_gem.o evdi_painter.o evdi_params.o evdi_cursor.o evdi_debug.o evdi_i2c.o
+ evdi-$(CONFIG_COMPAT) += evdi_ioc32.o
+ obj-$(CONFIG_DRM_EVDI) := evdi.o

--- a/evdi-el-fixes.diff
+++ b/evdi-el-fixes.diff
@@ -1,0 +1,70 @@
+diff -ru evdi-1.12.0-a/module/evdi_drm_drv.h evdi-1.12.0-b/module/evdi_drm_drv.h
+--- evdi-1.12.0-a/module/evdi_drm_drv.h	2022-11-25 12:52:30.000000000 -0500
++++ evdi-1.12.0-b/module/evdi_drm_drv.h	2022-11-25 13:41:41.628392700 -0500
+@@ -25,7 +25,7 @@
+ #else
+ #include <drm/drmP.h>
+ #endif
+-#if KERNEL_VERSION(5, 15, 0) <= LINUX_VERSION_CODE || defined(EL9)
++#if KERNEL_VERSION(5, 15, 0) <= LINUX_VERSION_CODE || defined(EL8) || defined(EL9)
+ #include <drm/drm_framebuffer.h>
+ #else
+ #include <drm/drm_irq.h>
+diff -ru evdi-1.12.0-a/module/evdi_gem.c evdi-1.12.0-b/module/evdi_gem.c
+--- evdi-1.12.0-a/module/evdi_gem.c	2022-11-25 12:52:30.000000000 -0500
++++ evdi-1.12.0-b/module/evdi_gem.c	2022-11-25 13:51:11.464137300 -0500
+@@ -10,7 +10,7 @@
+ 
+ #include <linux/sched.h>
+ #include <linux/version.h>
+-#if KERNEL_VERSION(5, 18, 0) <= LINUX_VERSION_CODE
++#if KERNEL_VERSION(5, 18, 0) <= LINUX_VERSION_CODE || defined(EL8) || defined(EL9)
+ #elif KERNEL_VERSION(5, 11, 0) <= LINUX_VERSION_CODE
+ #include <linux/dma-buf-map.h>
+ #endif
+@@ -291,7 +291,7 @@
+ 	int ret;
+ 
+ 	if (evdi_drm_gem_object_use_import_attach(&obj->base)) {
+-#if KERNEL_VERSION(5, 18, 0) <= LINUX_VERSION_CODE
++#if KERNEL_VERSION(5, 18, 0) <= LINUX_VERSION_CODE || defined(EL8) || defined(EL9)
+ 		struct iosys_map map = IOSYS_MAP_INIT_VADDR(NULL);
+ #elif KERNEL_VERSION(5, 11, 0) <= LINUX_VERSION_CODE || defined(EL8)
+ 		struct dma_buf_map map = DMA_BUF_MAP_INIT_VADDR(NULL);
+@@ -324,7 +324,7 @@
+ void evdi_gem_vunmap(struct evdi_gem_object *obj)
+ {
+ 	if (evdi_drm_gem_object_use_import_attach(&obj->base)) {
+-#if KERNEL_VERSION(5, 18, 0) <= LINUX_VERSION_CODE
++#if KERNEL_VERSION(5, 18, 0) <= LINUX_VERSION_CODE || defined(EL8) || defined(EL9)
+ 		struct iosys_map map = IOSYS_MAP_INIT_VADDR(NULL);
+ 
+ 		if (obj->vmap_is_iomem)
+Only in evdi-1.12.0-b/module: evdi_gem.c.oqBqCmy
+diff -ru evdi-1.12.0-a/module/evdi_ioc32.c evdi-1.12.0-b/module/evdi_ioc32.c
+--- evdi-1.12.0-a/module/evdi_ioc32.c	2022-11-25 12:52:30.000000000 -0500
++++ evdi-1.12.0-b/module/evdi_ioc32.c	2022-11-25 13:41:41.662675200 -0500
+@@ -62,9 +62,9 @@
+ 	if (copy_from_user(&req32, (void __user *)arg, sizeof(req32)))
+ 		return -EFAULT;
+ 
+-#if KERNEL_VERSION(5, 15, 0) <= LINUX_VERSION_CODE || defined(EL9)
++#if KERNEL_VERSION(5, 15, 0) <= LINUX_VERSION_CODE || defined(EL8) || defined(EL9)
+ 	request = kmalloc(sizeof(*request), GFP_USER);
+-#elif KERNEL_VERSION(5, 0, 0) <= LINUX_VERSION_CODE || defined(EL8)
++#elif KERNEL_VERSION(5, 0, 0) <= LINUX_VERSION_CODE
+ 	request = compat_alloc_user_space(sizeof(*request));
+ #endif
+ #if KERNEL_VERSION(5, 0, 0) <= LINUX_VERSION_CODE || defined(EL8)
+@@ -95,9 +95,9 @@
+ 	if (copy_from_user(&req32, (void __user *)arg, sizeof(req32)))
+ 		return -EFAULT;
+ 
+-#if KERNEL_VERSION(5, 15, 0) <= LINUX_VERSION_CODE || defined(EL9)
++#if KERNEL_VERSION(5, 15, 0) <= LINUX_VERSION_CODE || defined(EL8) || defined(EL9)
+ 	request = kmalloc(sizeof(*request), GFP_USER);
+-#elif KERNEL_VERSION(5, 0, 0) <= LINUX_VERSION_CODE || defined(EL8)
++#elif KERNEL_VERSION(5, 0, 0) <= LINUX_VERSION_CODE
+ 	request = compat_alloc_user_space(sizeof(*request));
+ #endif
+ #if KERNEL_VERSION(5, 0, 0) <= LINUX_VERSION_CODE || defined(EL8)


### PR DESCRIPTION
The currently released EVDI driver does not compile on newer distro releases.  There have been some patches merged into upstream but no release has been done.

The bundled version of EVDI is based on the current release as well.

Although we like to keep in step with the current release, there is no saying when the next version will be released.  This will hopefully help out those who need to move to a newer distro to not be held back anymore.