### PR TITLE
Fixes #297 : improve kernel package dependency handling - remove pagesize assumption & fix asahi linux support

### DIFF
--- a/displaylink.spec
+++ b/displaylink.spec
@@ -9,13 +9,8 @@
 
 %global debug_package %{nil}
 
-# asahi-linux is kernel-16k
-%global _kernel_pagesize %(getconf PAGE_SIZE | awk '{print $1/1024}')
-
 %if 0%{?rhel} && 0%{?rhel} <= 7
 %global kernel_pkg_name kernel-ml
-%elif 0%{?_kernel_pagesize} > 4
-%global kernel_pkg_name kernel-%{_kernel_pagesize}k
 %else
 %global kernel_pkg_name kernel
 %endif

--- a/displaylink.spec
+++ b/displaylink.spec
@@ -57,7 +57,8 @@ Requires: epel-release
 %endif
 
 Requires:   dkms
-Requires:   %{kernel_pkg_name} >= 4.15, %{kernel_pkg_name}-devel >= 4.15
+# Asahi Fedora requires kernel-16k, kernel-16k-devel.
+Requires:   ((%{kernel_pkg_name} >= 4.15 and %{kernel_pkg_name}-devel >= 4.15) or (kernel-16k >= 6.4 and kernel-16k-devel >= 6.4))
 Requires:   make
 Requires:   libusbx
 Requires:   xorg-x11-server-Xorg >= 1.16


### PR DESCRIPTION
This pull request includes changes to `DisplayLink.spec` to update the kernel package requirements and improve compatibility with general Fedora, Rhel-based distributions, and Asahi Linux Fedora.

Commit 1: Removed kernel's pagesize-based condition to derive kernel package name.
Pagesize-based condition forced the assumption that all distributions with 16k pagesize use kernel-16k package name. AFAIK, only Asahi Linux uses the kernel-16k package name.

Commit 2: Kernel package requirements update.
Updated the `Requires` section to include a conditional requirement for `kernel-16k` and `kernel-16k-devel`. This ensures compatibility with general fedora & rhel based distributions and Asahi Fedora.