### PR TITLE
spec: require Xwayland, recommend Xorg

### DIFF
--- a/displaylink.spec
+++ b/displaylink.spec
@@ -61,7 +61,10 @@ Requires:   dkms
 Requires:   ((%{kernel_pkg_name} >= 4.15 and %{kernel_pkg_name}-devel >= 4.15) or (kernel-16k >= 6.4 and kernel-16k-devel >= 6.4))
 Requires:   make
 Requires:   libusbx
-Requires:   xorg-x11-server-Xorg >= 1.16
+Requires:   xorg-x11-server-Xwayland >= 23
+# Xorg is removed in CentOS Stream 10 and Fedora 43+.
+# Recommend xorg-x11-server-Xorg but do not require it to avoid install failures on Wayland-only systems.
+Recommends:   xorg-x11-server-Xorg >= 1.16
 Conflicts:  mutter < 3.32
 Conflicts:  xorg-x11-server-Xorg = 1.20.1
 Conflicts:  libevdi%{libevdi_abi}


### PR DESCRIPTION
Require xorg-x11-server-Xwayland to support Wayland sessions. Recommend xorg-x11-server-Xorg for X11 systems but avoid a hard dependency to maintain compatibility with current distributions that still provide X11 support, as well as CentOS Stream 10 where Xorg has already been removed and upcoming distributions such as Fedora 43 where Xorg is expected to be removed.