### PR TITLE
Update to evdi 1.14.11 released on Github

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@
 #
 
 DAEMON_VERSION := 6.1.1-17
-VERSION        := 1.14.10
+VERSION        := 1.14.11
 RELEASE        := 1
 
 #

--- a/displaylink.spec
+++ b/displaylink.spec
@@ -255,6 +255,9 @@ fi
 %systemd_postun_with_restart displaylink-driver.service
 
 %changelog
+* Sun Sep 7 2025 cmprinho <cmprinho@icloud.com> 1.14.11
+- Update to evdi 1.14.11 that was released on Github
+
 * Wed May 14 2025 Michael L. Young <elgueromexicano@gmail.com> 1.14.10-1
 - Update to evdi 1.14.10 that was released on Github
 


### PR DESCRIPTION
This PR contains upstream changes for evdi [v1.14.11](https://github.com/DisplayLink/evdi/releases/tag/v1.14.11). 

